### PR TITLE
Included jQuery and react-bootstrap as modules rather than looking for globals, added gulp task, example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ bower_components
 
 # Dist zip
 bootstrap-select-*.zip
+
+# Example Dist
+app.js

--- a/examples/basic/app.jsx
+++ b/examples/basic/app.jsx
@@ -1,0 +1,34 @@
+var React = require('react');
+var { Nav, Navbar, Col } = require('react-bootstrap');
+var BootstrapSelect = require('../../jsx/Select');
+
+var Application = React.createClass({
+      displayName: 'Application',
+      render: function() {
+        var brand = <a className='navbar-brand' href="#">Bootstrap-select usability tests</a>;
+
+        return (
+          <div className='Application'>
+            <Navbar fixed-top={true} brand={brand}></Navbar>
+            <div className='container'>
+              <form className="form-horizontal">
+                <Col lg={10}>
+                  <BootstrapSelect label='"Basic"'>
+                    <option>cow</option>
+                    <option>bull</option>
+                    <option class="get-class" disabled>ox</option>
+                    <optgroup label="test" data-subtext="another test">
+                      <option>ASD</option>
+                      <option selected>Bla</option>
+                      <option>Ble</option>
+                    </optgroup>
+                  </BootstrapSelect>
+                </Col>
+              </form>
+            </div>
+          </div>
+        );
+      }
+  });
+
+React.render(<Application />, document.getElementById('content'));

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Bootstrap-select test page</title>
+
+  <meta charset="utf-8">
+
+  <link rel="stylesheet" type="text/css" href="../../dist/css/bootstrap-select.css">
+  <link href="//netdna.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
+
+</head>
+<body>
+    <div id="content"></div>
+    <script type="text/javascript" src="app.js"></script>
+</body>
+</html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,47 @@
+var gulp = require('gulp');
+var source = require('vinyl-source-stream');
+var fs = require('fs');
+var path = require('path');
+var merge = require('merge-stream');
+
+var browserify = require('browserify');
+var reactify = require('reactify');
+var babelify = require('babelify');
+var less = require('gulp-less');
+
+gulp.task('default', ['bundle']); 
+
+gulp.task('less', function () {
+  gulp.src('./less/bootstrap-select.less')
+    .pipe(less())
+    .pipe(gulp.dest('./dist/css'));
+});
+
+var examplesPath = './examples/';
+
+function getFolders(dir) {
+    return fs.readdirSync(dir)
+      .filter(function(file) {
+        return fs.statSync(path.join(dir, file)).isDirectory();
+      });
+}
+
+gulp.task('bundle', function() {
+  var folders = getFolders(examplesPath);
+
+  var tasks = folders.map(function(folder) {
+        return browserify({
+            entries: examplesPath + folder +'/app.jsx',
+            transform: [reactify, babelify]
+        })
+        .bundle()
+        .on('error', function(err){
+            console.log(err.toString());
+            this.emit('end');
+        })
+        .pipe(source('app.js'))
+        .pipe(gulp.dest(path.join(examplesPath, folder)));
+   });
+
+  return merge(tasks);
+});

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1,1373 +1,1374 @@
-'use strict';
 
-var $ = require('jQuery');
+  'use strict';
 
-//<editor-fold desc="Shims">
-if (!String.prototype.includes) {
-(function () {
-  'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
-  var toString = {}.toString;
-  var defineProperty = (function () {
-    // IE 8 only supports `Object.defineProperty` on DOM elements
-    try {
-      var object = {};
-      var $defineProperty = Object.defineProperty;
-      var result = $defineProperty(object, object, object) && $defineProperty;
-    } catch (error) {
-    }
-    return result;
-  }());
-  var indexOf = ''.indexOf;
-  var includes = function (search) {
-    if (this == null) {
-      throw TypeError();
-    }
-    var string = String(this);
-    if (search && toString.call(search) == '[object RegExp]') {
-      throw TypeError();
-    }
-    var stringLength = string.length;
-    var searchString = String(search);
-    var searchLength = searchString.length;
-    var position = arguments.length > 1 ? arguments[1] : undefined;
-    // `ToInteger`
-    var pos = position ? Number(position) : 0;
-    if (pos != pos) { // better `isNaN`
-      pos = 0;
-    }
-    var start = Math.min(Math.max(pos, 0), stringLength);
-    // Avoid the `indexOf` call if no match is possible
-    if (searchLength + start > stringLength) {
-      return false;
-    }
-    return indexOf.call(string, searchString, pos) != -1;
-  };
-  if (defineProperty) {
-    defineProperty(String.prototype, 'includes', {
-      'value': includes,
-      'configurable': true,
-      'writable': true
-    });
-  } else {
-    String.prototype.includes = includes;
-  }
-}());
-}
+  var jQuery = require('jQuery');
 
-if (!String.prototype.startsWith) {
-(function () {
-  'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
-  var defineProperty = (function () {
-    // IE 8 only supports `Object.defineProperty` on DOM elements
-    try {
-      var object = {};
-      var $defineProperty = Object.defineProperty;
-      var result = $defineProperty(object, object, object) && $defineProperty;
-    } catch (error) {
-    }
-    return result;
-  }());
-  var toString = {}.toString;
-  var startsWith = function (search) {
-    if (this == null) {
-      throw TypeError();
-    }
-    var string = String(this);
-    if (search && toString.call(search) == '[object RegExp]') {
-      throw TypeError();
-    }
-    var stringLength = string.length;
-    var searchString = String(search);
-    var searchLength = searchString.length;
-    var position = arguments.length > 1 ? arguments[1] : undefined;
-    // `ToInteger`
-    var pos = position ? Number(position) : 0;
-    if (pos != pos) { // better `isNaN`
-      pos = 0;
-    }
-    var start = Math.min(Math.max(pos, 0), stringLength);
-    // Avoid the `indexOf` call if no match is possible
-    if (searchLength + start > stringLength) {
-      return false;
-    }
-    var index = -1;
-    while (++index < searchLength) {
-      if (string.charCodeAt(start + index) != searchString.charCodeAt(index)) {
-        return false;
+  //<editor-fold desc="Shims">
+  if (!String.prototype.includes) {
+    (function () {
+      'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
+      var toString = {}.toString;
+      var defineProperty = (function () {
+        // IE 8 only supports `Object.defineProperty` on DOM elements
+        try {
+          var object = {};
+          var $defineProperty = Object.defineProperty;
+          var result = $defineProperty(object, object, object) && $defineProperty;
+        } catch (error) {
+        }
+        return result;
+      }());
+      var indexOf = ''.indexOf;
+      var includes = function (search) {
+        if (this == null) {
+          throw TypeError();
+        }
+        var string = String(this);
+        if (search && toString.call(search) == '[object RegExp]') {
+          throw TypeError();
+        }
+        var stringLength = string.length;
+        var searchString = String(search);
+        var searchLength = searchString.length;
+        var position = arguments.length > 1 ? arguments[1] : undefined;
+        // `ToInteger`
+        var pos = position ? Number(position) : 0;
+        if (pos != pos) { // better `isNaN`
+          pos = 0;
+        }
+        var start = Math.min(Math.max(pos, 0), stringLength);
+        // Avoid the `indexOf` call if no match is possible
+        if (searchLength + start > stringLength) {
+          return false;
+        }
+        return indexOf.call(string, searchString, pos) != -1;
+      };
+      if (defineProperty) {
+        defineProperty(String.prototype, 'includes', {
+          'value': includes,
+          'configurable': true,
+          'writable': true
+        });
+      } else {
+        String.prototype.includes = includes;
       }
-    }
-    return true;
-  };
-  if (defineProperty) {
-    defineProperty(String.prototype, 'startsWith', {
-      'value': startsWith,
-      'configurable': true,
-      'writable': true
-    });
-  } else {
-    String.prototype.startsWith = startsWith;
+    }());
   }
-}());
-}
-//</editor-fold>
 
-// Case insensitive contains search
-$.expr[':'].icontains = function (obj, index, meta) {
-var $obj = $(obj);
-var haystack = ($obj.data('tokens') || $obj.text()).toUpperCase();
-return haystack.includes(meta[3].toUpperCase());
-};
+  if (!String.prototype.startsWith) {
+    (function () {
+      'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
+      var defineProperty = (function () {
+        // IE 8 only supports `Object.defineProperty` on DOM elements
+        try {
+          var object = {};
+          var $defineProperty = Object.defineProperty;
+          var result = $defineProperty(object, object, object) && $defineProperty;
+        } catch (error) {
+        }
+        return result;
+      }());
+      var toString = {}.toString;
+      var startsWith = function (search) {
+        if (this == null) {
+          throw TypeError();
+        }
+        var string = String(this);
+        if (search && toString.call(search) == '[object RegExp]') {
+          throw TypeError();
+        }
+        var stringLength = string.length;
+        var searchString = String(search);
+        var searchLength = searchString.length;
+        var position = arguments.length > 1 ? arguments[1] : undefined;
+        // `ToInteger`
+        var pos = position ? Number(position) : 0;
+        if (pos != pos) { // better `isNaN`
+          pos = 0;
+        }
+        var start = Math.min(Math.max(pos, 0), stringLength);
+        // Avoid the `indexOf` call if no match is possible
+        if (searchLength + start > stringLength) {
+          return false;
+        }
+        var index = -1;
+        while (++index < searchLength) {
+          if (string.charCodeAt(start + index) != searchString.charCodeAt(index)) {
+            return false;
+          }
+        }
+        return true;
+      };
+      if (defineProperty) {
+        defineProperty(String.prototype, 'startsWith', {
+          'value': startsWith,
+          'configurable': true,
+          'writable': true
+        });
+      } else {
+        String.prototype.startsWith = startsWith;
+      }
+    }());
+  }
+  //</editor-fold>
 
-// Case insensitive begins search
-$.expr[':'].ibegins = function (obj, index, meta) {
-var $obj = $(obj);
-var haystack = ($obj.data('tokens') || $obj.text()).toUpperCase();
-return haystack.startsWith(meta[3].toUpperCase());
-};
+  // Case insensitive contains search
+  $.expr[':'].icontains = function (obj, index, meta) {
+    var $obj = $(obj);
+    var haystack = ($obj.data('tokens') || $obj.text()).toUpperCase();
+    return haystack.includes(meta[3].toUpperCase());
+  };
 
-// Case and accent insensitive contains search
-$.expr[':'].aicontains = function (obj, index, meta) {
-var $obj = $(obj);
-var haystack = ($obj.data('tokens') || $obj.data('normalizedText') || $obj.text()).toUpperCase();
-return haystack.includes(haystack, meta[3]);
-};
+  // Case insensitive begins search
+  $.expr[':'].ibegins = function (obj, index, meta) {
+    var $obj = $(obj);
+    var haystack = ($obj.data('tokens') || $obj.text()).toUpperCase();
+    return haystack.startsWith(meta[3].toUpperCase());
+  };
 
-// Case and accent insensitive begins search
-$.expr[':'].aibegins = function (obj, index, meta) {
-var $obj = $(obj);
-var haystack = ($obj.data('tokens') || $obj.data('normalizedText') || $obj.text()).toUpperCase();
-return haystack.startsWith(meta[3].toUpperCase());
-};
+  // Case and accent insensitive contains search
+  $.expr[':'].aicontains = function (obj, index, meta) {
+    var $obj = $(obj);
+    var haystack = ($obj.data('tokens') || $obj.data('normalizedText') || $obj.text()).toUpperCase();
+    return haystack.includes(haystack, meta[3]);
+  };
 
-/**
-* Remove all diatrics from the given text.
-* @access private
-* @param {String} text
-* @returns {String}
-*/
-function normalizeToBase(text) {
-var rExps = [
-  {re: /[\xC0-\xC6]/g, ch: "A"},
-  {re: /[\xE0-\xE6]/g, ch: "a"},
-  {re: /[\xC8-\xCB]/g, ch: "E"},
-  {re: /[\xE8-\xEB]/g, ch: "e"},
-  {re: /[\xCC-\xCF]/g, ch: "I"},
-  {re: /[\xEC-\xEF]/g, ch: "i"},
-  {re: /[\xD2-\xD6]/g, ch: "O"},
-  {re: /[\xF2-\xF6]/g, ch: "o"},
-  {re: /[\xD9-\xDC]/g, ch: "U"},
-  {re: /[\xF9-\xFC]/g, ch: "u"},
-  {re: /[\xC7-\xE7]/g, ch: "c"},
-  {re: /[\xD1]/g, ch: "N"},
-  {re: /[\xF1]/g, ch: "n"}
-];
-$.each(rExps, function () {
-  text = text.replace(this.re, this.ch);
-});
-return text;
-}
+  // Case and accent insensitive begins search
+  $.expr[':'].aibegins = function (obj, index, meta) {
+    var $obj = $(obj);
+    var haystack = ($obj.data('tokens') || $obj.data('normalizedText') || $obj.text()).toUpperCase();
+    return haystack.startsWith(meta[3].toUpperCase());
+  };
+
+  /**
+   * Remove all diatrics from the given text.
+   * @access private
+   * @param {String} text
+   * @returns {String}
+   */
+  function normalizeToBase(text) {
+    var rExps = [
+      {re: /[\xC0-\xC6]/g, ch: "A"},
+      {re: /[\xE0-\xE6]/g, ch: "a"},
+      {re: /[\xC8-\xCB]/g, ch: "E"},
+      {re: /[\xE8-\xEB]/g, ch: "e"},
+      {re: /[\xCC-\xCF]/g, ch: "I"},
+      {re: /[\xEC-\xEF]/g, ch: "i"},
+      {re: /[\xD2-\xD6]/g, ch: "O"},
+      {re: /[\xF2-\xF6]/g, ch: "o"},
+      {re: /[\xD9-\xDC]/g, ch: "U"},
+      {re: /[\xF9-\xFC]/g, ch: "u"},
+      {re: /[\xC7-\xE7]/g, ch: "c"},
+      {re: /[\xD1]/g, ch: "N"},
+      {re: /[\xF1]/g, ch: "n"}
+    ];
+    $.each(rExps, function () {
+      text = text.replace(this.re, this.ch);
+    });
+    return text;
+  }
 
 
-function htmlEscape(html) {
-var escapeMap = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-  "'": '&#x27;',
-  '`': '&#x60;'
-};
-var source = '(?:' + Object.keys(escapeMap).join('|') + ')',
-    testRegexp = new RegExp(source),
-    replaceRegexp = new RegExp(source, 'g'),
-    string = html == null ? '' : '' + html;
-return testRegexp.test(string) ? string.replace(replaceRegexp, function (match) {
-  return escapeMap[match];
-}) : string;
-}
+  function htmlEscape(html) {
+    var escapeMap = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#x27;',
+      '`': '&#x60;'
+    };
+    var source = '(?:' + Object.keys(escapeMap).join('|') + ')',
+        testRegexp = new RegExp(source),
+        replaceRegexp = new RegExp(source, 'g'),
+        string = html == null ? '' : '' + html;
+    return testRegexp.test(string) ? string.replace(replaceRegexp, function (match) {
+      return escapeMap[match];
+    }) : string;
+  }
 
-var Selectpicker = function (element, options, e) {
-if (e) {
-  e.stopPropagation();
-  e.preventDefault();
-}
-
-this.$element = $(element);
-this.$newElement = null;
-this.$button = null;
-this.$menu = null;
-this.$lis = null;
-this.options = options;
-
-// If we have no title yet, try to pull it from the html title attribute (jQuery doesnt' pick it up as it's not a
-// data-attribute)
-if (this.options.title === null) {
-  this.options.title = this.$element.attr('title');
-}
-
-//Expose public methods
-this.val = Selectpicker.prototype.val;
-this.render = Selectpicker.prototype.render;
-this.refresh = Selectpicker.prototype.refresh;
-this.setStyle = Selectpicker.prototype.setStyle;
-this.selectAll = Selectpicker.prototype.selectAll;
-this.deselectAll = Selectpicker.prototype.deselectAll;
-this.destroy = Selectpicker.prototype.remove;
-this.remove = Selectpicker.prototype.remove;
-this.show = Selectpicker.prototype.show;
-this.hide = Selectpicker.prototype.hide;
-
-this.init();
-};
-
-Selectpicker.VERSION = '1.6.3';
-
-// part of this is duplicated in i18n/defaults-en_US.js. Make sure to update both.
-Selectpicker.DEFAULTS = {
-noneSelectedText: 'Nothing selected',
-noneResultsText: 'No results matched {0}',
-countSelectedText: function (numSelected, numTotal) {
-  return (numSelected == 1) ? "{0} item selected" : "{0} items selected";
-},
-maxOptionsText: function (numAll, numGroup) {
-  return [
-    (numAll == 1) ? 'Limit reached ({n} item max)' : 'Limit reached ({n} items max)',
-    (numGroup == 1) ? 'Group limit reached ({n} item max)' : 'Group limit reached ({n} items max)'
-  ];
-},
-selectAllText: 'Select All',
-deselectAllText: 'Deselect All',
-doneButton: false,
-doneButtonText: 'Close',
-multipleSeparator: ', ',
-style: 'btn-default',
-size: 'auto',
-title: null,
-selectedTextFormat: 'values',
-width: false,
-container: false,
-hideDisabled: false,
-showSubtext: false,
-showIcon: true,
-showContent: true,
-dropupAuto: true,
-header: false,
-liveSearch: false,
-liveSearchPlaceholder: null,
-liveSearchNormalize: false,
-liveSearchStyle: 'contains',
-actionsBox: false,
-iconBase: 'glyphicon',
-tickIcon: 'glyphicon-ok',
-maxOptions: false,
-mobile: false,
-selectOnTab: false,
-dropdownAlignRight: false
-};
-
-Selectpicker.prototype = {
-
-constructor: Selectpicker,
-
-init: function () {
-  var that = this,
-      id = this.$element.attr('id');
-
-  this.$element.hide();
-  this.multiple = this.$element.prop('multiple');
-  this.autofocus = this.$element.prop('autofocus');
-  this.$newElement = this.createView();
-  this.$element.after(this.$newElement);
-  this.$menu = this.$newElement.children('.dropdown-menu');
-  this.$button = this.$newElement.children('button');
-  this.$searchbox = this.$newElement.find('input');
-
-  if (this.options.dropdownAlignRight)
-    this.$menu.addClass('dropdown-menu-right');
-
-  if (typeof id !== 'undefined') {
-    this.$button.attr('data-id', id);
-    $('label[for="' + id + '"]').click(function (e) {
+  var Selectpicker = function (element, options, e) {
+    if (e) {
+      e.stopPropagation();
       e.preventDefault();
-      that.$button.focus();
-    });
-  }
+    }
 
-  this.checkDisabled();
-  this.clickListener();
-  if (this.options.liveSearch) this.liveSearchListener();
-  this.render();
-  this.liHeight();
-  this.setStyle();
-  this.setWidth();
-  if (this.options.container) this.selectPosition();
-  this.$menu.data('this', this);
-  this.$newElement.data('this', this);
-  if (this.options.mobile) this.mobile();
-},
+    this.$element = $(element);
+    this.$newElement = null;
+    this.$button = null;
+    this.$menu = null;
+    this.$lis = null;
+    this.options = options;
 
-createDropdown: function () {
-  // Options
-  // If we are multiple, then add the show-tick class by default
-  var multiple = this.multiple ? ' show-tick' : '',
-      inputGroup = this.$element.parent().hasClass('input-group') ? ' input-group-btn' : '',
-      autofocus = this.autofocus ? ' autofocus' : '';
-  // Elements
-  var header = this.options.header ? '<div class="popover-title"><button type="button" class="close" aria-hidden="true">&times;</button>' + this.options.header + '</div>' : '';
-  var searchbox = this.options.liveSearch ?
-  '<div class="bs-searchbox">' +
-  '<input type="text" class="form-control" autocomplete="off"' +
-  (null === this.options.liveSearchPlaceholder ? '' : ' placeholder="' + htmlEscape(this.options.liveSearchPlaceholder) + '"') + '>' +
-  '</div>'
-      : '';
-  var actionsbox = this.multiple && this.options.actionsBox ?
-  '<div class="bs-actionsbox">' +
-  '<div class="btn-group btn-group-sm btn-block">' +
-  '<button class="actions-btn bs-select-all btn btn-default">' +
-  this.options.selectAllText +
-  '</button>' +
-  '<button class="actions-btn bs-deselect-all btn btn-default">' +
-  this.options.deselectAllText +
-  '</button>' +
-  '</div>' +
-  '</div>'
-      : '';
-  var donebutton = this.multiple && this.options.doneButton ?
-  '<div class="bs-donebutton">' +
-  '<div class="btn-group btn-block">' +
-  '<button class="btn btn-sm btn-default">' +
-  this.options.doneButtonText +
-  '</button>' +
-  '</div>' +
-  '</div>'
-      : '';
-  var drop =
-      '<div class="btn-group bootstrap-select' + multiple + inputGroup + '">' +
-      '<button type="button" class="btn dropdown-toggle form-control selectpicker" data-toggle="dropdown"' + autofocus + '>' +
-      '<span class="filter-option pull-left"></span>&nbsp;' +
-      '<span class="caret"></span>' +
+    // If we have no title yet, try to pull it from the html title attribute (jQuery doesnt' pick it up as it's not a
+    // data-attribute)
+    if (this.options.title === null) {
+      this.options.title = this.$element.attr('title');
+    }
+
+    //Expose public methods
+    this.val = Selectpicker.prototype.val;
+    this.render = Selectpicker.prototype.render;
+    this.refresh = Selectpicker.prototype.refresh;
+    this.setStyle = Selectpicker.prototype.setStyle;
+    this.selectAll = Selectpicker.prototype.selectAll;
+    this.deselectAll = Selectpicker.prototype.deselectAll;
+    this.destroy = Selectpicker.prototype.remove;
+    this.remove = Selectpicker.prototype.remove;
+    this.show = Selectpicker.prototype.show;
+    this.hide = Selectpicker.prototype.hide;
+
+    this.init();
+  };
+
+  Selectpicker.VERSION = '1.6.3';
+
+  // part of this is duplicated in i18n/defaults-en_US.js. Make sure to update both.
+  Selectpicker.DEFAULTS = {
+    noneSelectedText: 'Nothing selected',
+    noneResultsText: 'No results matched {0}',
+    countSelectedText: function (numSelected, numTotal) {
+      return (numSelected == 1) ? "{0} item selected" : "{0} items selected";
+    },
+    maxOptionsText: function (numAll, numGroup) {
+      return [
+        (numAll == 1) ? 'Limit reached ({n} item max)' : 'Limit reached ({n} items max)',
+        (numGroup == 1) ? 'Group limit reached ({n} item max)' : 'Group limit reached ({n} items max)'
+      ];
+    },
+    selectAllText: 'Select All',
+    deselectAllText: 'Deselect All',
+    doneButton: false,
+    doneButtonText: 'Close',
+    multipleSeparator: ', ',
+    style: 'btn-default',
+    size: 'auto',
+    title: null,
+    selectedTextFormat: 'values',
+    width: false,
+    container: false,
+    hideDisabled: false,
+    showSubtext: false,
+    showIcon: true,
+    showContent: true,
+    dropupAuto: true,
+    header: false,
+    liveSearch: false,
+    liveSearchPlaceholder: null,
+    liveSearchNormalize: false,
+    liveSearchStyle: 'contains',
+    actionsBox: false,
+    iconBase: 'glyphicon',
+    tickIcon: 'glyphicon-ok',
+    maxOptions: false,
+    mobile: false,
+    selectOnTab: false,
+    dropdownAlignRight: false
+  };
+
+  Selectpicker.prototype = {
+
+    constructor: Selectpicker,
+
+    init: function () {
+      var that = this,
+          id = this.$element.attr('id');
+
+      this.$element.hide();
+      this.multiple = this.$element.prop('multiple');
+      this.autofocus = this.$element.prop('autofocus');
+      this.$newElement = this.createView();
+      this.$element.after(this.$newElement);
+      this.$menu = this.$newElement.children('.dropdown-menu');
+      this.$button = this.$newElement.children('button');
+      this.$searchbox = this.$newElement.find('input');
+
+      if (this.options.dropdownAlignRight)
+        this.$menu.addClass('dropdown-menu-right');
+
+      if (typeof id !== 'undefined') {
+        this.$button.attr('data-id', id);
+        $('label[for="' + id + '"]').click(function (e) {
+          e.preventDefault();
+          that.$button.focus();
+        });
+      }
+
+      this.checkDisabled();
+      this.clickListener();
+      if (this.options.liveSearch) this.liveSearchListener();
+      this.render();
+      this.liHeight();
+      this.setStyle();
+      this.setWidth();
+      if (this.options.container) this.selectPosition();
+      this.$menu.data('this', this);
+      this.$newElement.data('this', this);
+      if (this.options.mobile) this.mobile();
+    },
+
+    createDropdown: function () {
+      // Options
+      // If we are multiple, then add the show-tick class by default
+      var multiple = this.multiple ? ' show-tick' : '',
+          inputGroup = this.$element.parent().hasClass('input-group') ? ' input-group-btn' : '',
+          autofocus = this.autofocus ? ' autofocus' : '';
+      // Elements
+      var header = this.options.header ? '<div class="popover-title"><button type="button" class="close" aria-hidden="true">&times;</button>' + this.options.header + '</div>' : '';
+      var searchbox = this.options.liveSearch ?
+      '<div class="bs-searchbox">' +
+      '<input type="text" class="form-control" autocomplete="off"' +
+      (null === this.options.liveSearchPlaceholder ? '' : ' placeholder="' + htmlEscape(this.options.liveSearchPlaceholder) + '"') + '>' +
+      '</div>'
+          : '';
+      var actionsbox = this.multiple && this.options.actionsBox ?
+      '<div class="bs-actionsbox">' +
+      '<div class="btn-group btn-group-sm btn-block">' +
+      '<button class="actions-btn bs-select-all btn btn-default">' +
+      this.options.selectAllText +
       '</button>' +
-      '<div class="dropdown-menu open">' +
-      header +
-      searchbox +
-      actionsbox +
-      '<ul class="dropdown-menu inner selectpicker" role="menu">' +
-      '</ul>' +
-      donebutton +
+      '<button class="actions-btn bs-deselect-all btn btn-default">' +
+      this.options.deselectAllText +
+      '</button>' +
       '</div>' +
-      '</div>';
+      '</div>'
+          : '';
+      var donebutton = this.multiple && this.options.doneButton ?
+      '<div class="bs-donebutton">' +
+      '<div class="btn-group btn-block">' +
+      '<button class="btn btn-sm btn-default">' +
+      this.options.doneButtonText +
+      '</button>' +
+      '</div>' +
+      '</div>'
+          : '';
+      var drop =
+          '<div class="btn-group bootstrap-select' + multiple + inputGroup + '">' +
+          '<button type="button" class="btn dropdown-toggle form-control selectpicker" data-toggle="dropdown"' + autofocus + '>' +
+          '<span class="filter-option pull-left"></span>&nbsp;' +
+          '<span class="caret"></span>' +
+          '</button>' +
+          '<div class="dropdown-menu open">' +
+          header +
+          searchbox +
+          actionsbox +
+          '<ul class="dropdown-menu inner selectpicker" role="menu">' +
+          '</ul>' +
+          donebutton +
+          '</div>' +
+          '</div>';
 
-  return $(drop);
-},
+      return $(drop);
+    },
 
-createView: function () {
-  var $drop = this.createDropdown();
-  var $li = this.createLi();
-  $drop.find('ul').append($li);
-  return $drop;
-},
+    createView: function () {
+      var $drop = this.createDropdown();
+      var $li = this.createLi();
+      $drop.find('ul').append($li);
+      return $drop;
+    },
 
-reloadLi: function () {
-  //Remove all children.
-  this.destroyLi();
-  //Re build
-  var $li = this.createLi();
-  this.$menu.find('ul').append($li);
-},
+    reloadLi: function () {
+      //Remove all children.
+      this.destroyLi();
+      //Re build
+      var $li = this.createLi();
+      this.$menu.find('ul').append($li);
+    },
 
-destroyLi: function () {
-  this.$menu.find('li').remove();
-},
+    destroyLi: function () {
+      this.$menu.find('li').remove();
+    },
 
-createLi: function () {
-  var that = this,
-      _li = [],
-      optID = 0;
+    createLi: function () {
+      var that = this,
+          _li = [],
+          optID = 0;
 
-  // Helper functions
-  /**
-   * @param content
-   * @param [index]
-   * @param [classes]
-   * @param [optgroup]
-   * @returns {string}
-   */
-  var generateLI = function (content, index, classes, optgroup) {
-    return '<li' +
-        ((typeof classes !== 'undefined' & '' !== classes) ? ' class="' + classes + '"' : '') +
-        ((typeof index !== 'undefined' & null !== index) ? ' data-original-index="' + index + '"' : '') +
-        ((typeof optgroup !== 'undefined' & null !== optgroup) ? 'data-optgroup="' + optgroup + '"' : '') +
-        '>' + content + '</li>';
-  };
+      // Helper functions
+      /**
+       * @param content
+       * @param [index]
+       * @param [classes]
+       * @param [optgroup]
+       * @returns {string}
+       */
+      var generateLI = function (content, index, classes, optgroup) {
+        return '<li' +
+            ((typeof classes !== 'undefined' & '' !== classes) ? ' class="' + classes + '"' : '') +
+            ((typeof index !== 'undefined' & null !== index) ? ' data-original-index="' + index + '"' : '') +
+            ((typeof optgroup !== 'undefined' & null !== optgroup) ? 'data-optgroup="' + optgroup + '"' : '') +
+            '>' + content + '</li>';
+      };
 
-  /**
-   * @param text
-   * @param [classes]
-   * @param [inline]
-   * @param [tokens]
-   * @returns {string}
-   */
-  var generateA = function (text, classes, inline, tokens) {
-    return '<a tabindex="0"' +
-        (typeof classes !== 'undefined' ? ' class="' + classes + '"' : '') +
-        (typeof inline !== 'undefined' ? ' style="' + inline + '"' : '') +
-        ' data-normalized-text="' + normalizeToBase(htmlEscape(text)) + '"' +
-        (typeof tokens !== 'undefined' || tokens !== null ? ' data-tokens="' + tokens + '"' : '') +
-        '>' + text +
-        '<span class="' + that.options.iconBase + ' ' + that.options.tickIcon + ' check-mark"></span>' +
-        '</a>';
-  };
+      /**
+       * @param text
+       * @param [classes]
+       * @param [inline]
+       * @param [tokens]
+       * @returns {string}
+       */
+      var generateA = function (text, classes, inline, tokens) {
+        return '<a tabindex="0"' +
+            (typeof classes !== 'undefined' ? ' class="' + classes + '"' : '') +
+            (typeof inline !== 'undefined' ? ' style="' + inline + '"' : '') +
+            ' data-normalized-text="' + normalizeToBase(htmlEscape(text)) + '"' +
+            (typeof tokens !== 'undefined' || tokens !== null ? ' data-tokens="' + tokens + '"' : '') +
+            '>' + text +
+            '<span class="' + that.options.iconBase + ' ' + that.options.tickIcon + ' check-mark"></span>' +
+            '</a>';
+      };
 
-  this.$element.find('option').each(function (index) {
-    var $this = $(this);
+      this.$element.find('option').each(function (index) {
+        var $this = $(this);
 
-    // Get the class and text for the option
-    var optionClass = $this.attr('class') || '',
-        inline = $this.attr('style'),
-        text = $this.data('content') ? $this.data('content') : $this.html(),
-        tokens = $this.data('tokens') ? $this.data('tokens') : null,
-        subtext = typeof $this.data('subtext') !== 'undefined' ? '<small class="text-muted">' + $this.data('subtext') + '</small>' : '',
-        icon = typeof $this.data('icon') !== 'undefined' ? '<span class="' + that.options.iconBase + ' ' + $this.data('icon') + '"></span> ' : '',
-        isDisabled = $this.is(':disabled') || $this.parent().is(':disabled');
-    if (icon !== '' && isDisabled) {
-      icon = '<span>' + icon + '</span>';
-    }
-
-    if (!$this.data('content')) {
-      // Prepend any icon and append any subtext to the main text.
-      text = icon + '<span class="text">' + text + subtext + '</span>';
-    }
-
-    if (that.options.hideDisabled && isDisabled) {
-      return;
-    }
-
-    if ($this.parent().is('optgroup') && $this.data('divider') !== true) {
-      if ($this.index() === 0) { // Is it the first option of the optgroup?
-        optID += 1;
-
-        // Get the opt group label
-        var label = $this.parent().attr('label');
-        var labelSubtext = typeof $this.parent().data('subtext') !== 'undefined' ? '<small class="text-muted">' + $this.parent().data('subtext') + '</small>' : '';
-        var labelIcon = $this.parent().data('icon') ? '<span class="' + that.options.iconBase + ' ' + $this.parent().data('icon') + '"></span> ' : '';
-        label = labelIcon + '<span class="text">' + label + labelSubtext + '</span>';
-
-        if (index !== 0 && _li.length > 0) { // Is it NOT the first option of the select && are there elements in the dropdown?
-          _li.push(generateLI('', null, 'divider'));
+        // Get the class and text for the option
+        var optionClass = $this.attr('class') || '',
+            inline = $this.attr('style'),
+            text = $this.data('content') ? $this.data('content') : $this.html(),
+            tokens = $this.data('tokens') ? $this.data('tokens') : null,
+            subtext = typeof $this.data('subtext') !== 'undefined' ? '<small class="text-muted">' + $this.data('subtext') + '</small>' : '',
+            icon = typeof $this.data('icon') !== 'undefined' ? '<span class="' + that.options.iconBase + ' ' + $this.data('icon') + '"></span> ' : '',
+            isDisabled = $this.is(':disabled') || $this.parent().is(':disabled');
+        if (icon !== '' && isDisabled) {
+          icon = '<span>' + icon + '</span>';
         }
 
-        _li.push(generateLI(label, null, 'dropdown-header', optID));
-      }
+        if (!$this.data('content')) {
+          // Prepend any icon and append any subtext to the main text.
+          text = icon + '<span class="text">' + text + subtext + '</span>';
+        }
 
-      _li.push(generateLI(generateA(text, 'opt ' + optionClass, inline, tokens), index, '', optID));
-    } else if ($this.data('divider') === true) {
-      _li.push(generateLI('', index, 'divider'));
-    } else if ($this.data('hidden') === true) {
-      _li.push(generateLI(generateA(text, optionClass, inline, tokens), index, 'hidden is-hidden'));
-    } else {
-      _li.push(generateLI(generateA(text, optionClass, inline, tokens), index));
-    }
-  });
+        if (that.options.hideDisabled && isDisabled) {
+          return;
+        }
 
-  //If we are not multiple, we don't have a selected item, and we don't have a title, select the first element so something is set in the button
-  if (!this.multiple && this.$element.find('option:selected').length === 0 && !this.options.title) {
-    this.$element.find('option').eq(0).prop('selected', true).attr('selected', 'selected');
-  }
+        if ($this.parent().is('optgroup') && $this.data('divider') !== true) {
+          if ($this.index() === 0) { // Is it the first option of the optgroup?
+            optID += 1;
 
-  return $(_li.join(''));
-},
+            // Get the opt group label
+            var label = $this.parent().attr('label');
+            var labelSubtext = typeof $this.parent().data('subtext') !== 'undefined' ? '<small class="text-muted">' + $this.parent().data('subtext') + '</small>' : '';
+            var labelIcon = $this.parent().data('icon') ? '<span class="' + that.options.iconBase + ' ' + $this.parent().data('icon') + '"></span> ' : '';
+            label = labelIcon + '<span class="text">' + label + labelSubtext + '</span>';
 
-findLis: function () {
-  if (this.$lis == null) this.$lis = this.$menu.find('li');
-  return this.$lis;
-},
+            if (index !== 0 && _li.length > 0) { // Is it NOT the first option of the select && are there elements in the dropdown?
+              _li.push(generateLI('', null, 'divider'));
+            }
 
-/**
- * @param [updateLi] defaults to true
- */
-render: function (updateLi) {
-  var that = this;
+            _li.push(generateLI(label, null, 'dropdown-header', optID));
+          }
 
-  //Update the LI to match the SELECT
-  if (updateLi !== false) {
-    this.$element.find('option').each(function (index) {
-      that.setDisabled(index, $(this).is(':disabled') || $(this).parent().is(':disabled'));
-      that.setSelected(index, $(this).is(':selected'));
-    });
-  }
-
-  this.tabIndex();
-  var notDisabled = this.options.hideDisabled ? ':not([disabled])' : '';
-  var selectedItems = this.$element.find('option:selected' + notDisabled).map(function () {
-    var $this = $(this);
-    var icon = $this.data('icon') && that.options.showIcon ? '<i class="' + that.options.iconBase + ' ' + $this.data('icon') + '"></i> ' : '';
-    var subtext;
-    if (that.options.showSubtext && $this.attr('data-subtext') && !that.multiple) {
-      subtext = ' <small class="text-muted">' + $this.data('subtext') + '</small>';
-    } else {
-      subtext = '';
-    }
-    if (typeof $this.attr('title') !== 'undefined') {
-      return $this.attr('title');
-    } else if ($this.data('content') && that.options.showContent) {
-      return $this.data('content');
-    } else {
-      return icon + $this.html() + subtext;
-    }
-  }).toArray();
-
-  //Fixes issue in IE10 occurring when no default option is selected and at least one option is disabled
-  //Convert all the values into a comma delimited string
-  var title = !this.multiple ? selectedItems[0] : selectedItems.join(this.options.multipleSeparator);
-
-  //If this is multi select, and the selectText type is count, the show 1 of 2 selected etc..
-  if (this.multiple && this.options.selectedTextFormat.indexOf('count') > -1) {
-    var max = this.options.selectedTextFormat.split('>');
-    if ((max.length > 1 && selectedItems.length > max[1]) || (max.length == 1 && selectedItems.length >= 2)) {
-      notDisabled = this.options.hideDisabled ? ', [disabled]' : '';
-      var totalCount = this.$element.find('option').not('[data-divider="true"], [data-hidden="true"]' + notDisabled).length,
-          tr8nText = (typeof this.options.countSelectedText === 'function') ? this.options.countSelectedText(selectedItems.length, totalCount) : this.options.countSelectedText;
-      title = tr8nText.replace('{0}', selectedItems.length.toString()).replace('{1}', totalCount.toString());
-    }
-  }
-
-  if (this.options.title == undefined) {
-    this.options.title = this.$element.attr('title');
-  }
-
-  if (this.options.selectedTextFormat == 'static') {
-    title = this.options.title;
-  }
-
-  //If we dont have a title, then use the default, or if nothing is set at all, use the not selected text
-  if (!title) {
-    title = typeof this.options.title !== 'undefined' ? this.options.title : this.options.noneSelectedText;
-  }
-
-  //strip all html-tags and trim the result
-  this.$button.attr('title', $.trim(title.replace(/<[^>]*>?/g, '')));
-  this.$newElement.find('.filter-option').html(title);
-},
-
-/**
- * @param [style]
- * @param [status]
- */
-setStyle: function (style, status) {
-  if (this.$element.attr('class')) {
-    this.$newElement.addClass(this.$element.attr('class').replace(/selectpicker|mobile-device|validate\[.*\]/gi, ''));
-  }
-
-  var buttonClass = style ? style : this.options.style;
-
-  if (status == 'add') {
-    this.$button.addClass(buttonClass);
-  } else if (status == 'remove') {
-    this.$button.removeClass(buttonClass);
-  } else {
-    this.$button.removeClass(this.options.style);
-    this.$button.addClass(buttonClass);
-  }
-},
-
-liHeight: function () {
-  if (this.options.size === false) return;
-
-  var $selectClone = this.$menu.parent().clone().children('.dropdown-toggle').prop('autofocus', false).end().appendTo('body'),
-      $menuClone = $selectClone.addClass('open').children('.dropdown-menu'),
-      liHeight = $menuClone.find('li').not('.divider').not('.dropdown-header').filter(':visible').children('a').outerHeight(),
-      headerHeight = this.options.header ? $menuClone.find('.popover-title').outerHeight() : 0,
-      searchHeight = this.options.liveSearch ? $menuClone.find('.bs-searchbox').outerHeight() : 0,
-      actionsHeight = this.options.actionsBox ? $menuClone.find('.bs-actionsbox').outerHeight() : 0,
-      doneButtonHeight = this.multiple ? $menuClone.find('.bs-donebutton').outerHeight() : 0;
-
-  $selectClone.remove();
-
-  this.$newElement
-      .data('liHeight', liHeight)
-      .data('headerHeight', headerHeight)
-      .data('searchHeight', searchHeight)
-      .data('actionsHeight', actionsHeight)
-      .data('doneButtonHeight', doneButtonHeight);
-},
-
-setSize: function () {
-  this.findLis();
-  var that = this,
-      menu = this.$menu,
-      menuInner = menu.find('.inner'),
-      selectHeight = this.$newElement.outerHeight(),
-      liHeight = this.$newElement.data('liHeight'),
-      headerHeight = this.$newElement.data('headerHeight'),
-      searchHeight = this.$newElement.data('searchHeight'),
-      actionsHeight = this.$newElement.data('actionsHeight'),
-      doneButtonHeight = this.$newElement.data('doneButtonHeight'),
-      divHeight = this.$lis.filter('.divider').outerHeight(true),
-      menuPadding = parseInt(menu.css('padding-top')) +
-          parseInt(menu.css('padding-bottom')) +
-          parseInt(menu.css('border-top-width')) +
-          parseInt(menu.css('border-bottom-width')),
-      notDisabled = this.options.hideDisabled ? ', .disabled' : '',
-      $window = $(window),
-      menuExtras = menuPadding + parseInt(menu.css('margin-top')) + parseInt(menu.css('margin-bottom')) + 2,
-      menuHeight,
-      selectOffsetTop,
-      selectOffsetBot,
-      posVert = function () {
-        // JQuery defines a scrollTop function, but in pure JS it's a property
-        //noinspection JSValidateTypes
-        selectOffsetTop = that.$newElement.offset().top - $window.scrollTop();
-        selectOffsetBot = $window.height() - selectOffsetTop - selectHeight;
-      };
-  posVert();
-  if (this.options.header) menu.css('padding-top', 0);
-
-  if (this.options.size == 'auto') {
-    var getSize = function () {
-      var minHeight,
-          lisVis = that.$lis.not('.hidden');
-
-      posVert();
-      menuHeight = selectOffsetBot - menuExtras;
-
-      if (that.options.dropupAuto) {
-        that.$newElement.toggleClass('dropup', selectOffsetTop > selectOffsetBot && (menuHeight - menuExtras) < menu.height());
-      }
-      if (that.$newElement.hasClass('dropup')) {
-        menuHeight = selectOffsetTop - menuExtras;
-      }
-
-      if ((lisVis.length + lisVis.filter('.dropdown-header').length) > 3) {
-        minHeight = liHeight * 3 + menuExtras - 2;
-      } else {
-        minHeight = 0;
-      }
-
-      menu.css({
-        'max-height': menuHeight + 'px',
-        'overflow': 'hidden',
-        'min-height': minHeight + headerHeight + searchHeight + actionsHeight + doneButtonHeight + 'px'
+          _li.push(generateLI(generateA(text, 'opt ' + optionClass, inline, tokens), index, '', optID));
+        } else if ($this.data('divider') === true) {
+          _li.push(generateLI('', index, 'divider'));
+        } else if ($this.data('hidden') === true) {
+          _li.push(generateLI(generateA(text, optionClass, inline, tokens), index, 'hidden is-hidden'));
+        } else {
+          _li.push(generateLI(generateA(text, optionClass, inline, tokens), index));
+        }
       });
-      menuInner.css({
-        'max-height': menuHeight - headerHeight - searchHeight - actionsHeight - doneButtonHeight - menuPadding + 'px',
-        'overflow-y': 'auto',
-        'min-height': Math.max(minHeight - menuPadding, 0) + 'px'
-      });
-    };
-    getSize();
-    this.$searchbox.off('input.getSize propertychange.getSize').on('input.getSize propertychange.getSize', getSize);
-    $window.off('resize.getSize').on('resize.getSize', getSize);
-    $window.off('scroll.getSize').on('scroll.getSize', getSize);
-  } else if (this.options.size && this.options.size != 'auto' && menu.find('li' + notDisabled).length > this.options.size) {
-    var optIndex = this.$lis.not('.divider' + notDisabled).children().slice(0, this.options.size).last().parent().index();
-    var divLength = this.$lis.slice(0, optIndex + 1).filter('.divider').length;
-    menuHeight = liHeight * this.options.size + divLength * divHeight + menuPadding;
-    if (that.options.dropupAuto) {
-      //noinspection JSUnusedAssignment
-      this.$newElement.toggleClass('dropup', selectOffsetTop > selectOffsetBot && menuHeight < menu.height());
-    }
-    menu.css({
-      'max-height': menuHeight + headerHeight + searchHeight + actionsHeight + doneButtonHeight + 'px',
-      'overflow': 'hidden'
-    });
-    menuInner.css({'max-height': menuHeight - menuPadding + 'px', 'overflow-y': 'auto'});
-  }
-},
 
-setWidth: function () {
-  if (this.options.width == 'auto') {
-    this.$menu.css('min-width', '0');
+      //If we are not multiple, we don't have a selected item, and we don't have a title, select the first element so something is set in the button
+      if (!this.multiple && this.$element.find('option:selected').length === 0 && !this.options.title) {
+        this.$element.find('option').eq(0).prop('selected', true).attr('selected', 'selected');
+      }
 
-    // Get correct width if element hidden
-    var selectClone = this.$newElement.clone().appendTo('body');
-    var ulWidth = selectClone.children('.dropdown-menu').css('width');
-    var btnWidth = selectClone.css('width', 'auto').children('button').css('width');
-    selectClone.remove();
+      return $(_li.join(''));
+    },
 
-    // Set width to whatever's larger, button title or longest option
-    this.$newElement.css('width', Math.max(parseInt(ulWidth), parseInt(btnWidth)) + 'px');
-  } else if (this.options.width == 'fit') {
-    // Remove inline min-width so width can be changed from 'auto'
-    this.$menu.css('min-width', '');
-    this.$newElement.css('width', '').addClass('fit-width');
-  } else if (this.options.width) {
-    // Remove inline min-width so width can be changed from 'auto'
-    this.$menu.css('min-width', '');
-    this.$newElement.css('width', this.options.width);
-  } else {
-    // Remove inline min-width/width so width can be changed
-    this.$menu.css('min-width', '');
-    this.$newElement.css('width', '');
-  }
-  // Remove fit-width class if width is changed programmatically
-  if (this.$newElement.hasClass('fit-width') && this.options.width !== 'fit') {
-    this.$newElement.removeClass('fit-width');
-  }
-},
+    findLis: function () {
+      if (this.$lis == null) this.$lis = this.$menu.find('li');
+      return this.$lis;
+    },
 
-selectPosition: function () {
-  var that = this,
-      drop = '<div />',
-      $drop = $(drop),
-      pos,
-      actualHeight,
-      getPlacement = function ($element) {
-        $drop.addClass($element.attr('class').replace(/form-control/gi, '')).toggleClass('dropup', $element.hasClass('dropup'));
-        pos = $element.offset();
-        actualHeight = $element.hasClass('dropup') ? 0 : $element[0].offsetHeight;
-        $drop.css({
-          'top': pos.top + actualHeight,
-          'left': pos.left,
-          'width': $element[0].offsetWidth,
-          'position': 'absolute'
+    /**
+     * @param [updateLi] defaults to true
+     */
+    render: function (updateLi) {
+      var that = this;
+
+      //Update the LI to match the SELECT
+      if (updateLi !== false) {
+        this.$element.find('option').each(function (index) {
+          that.setDisabled(index, $(this).is(':disabled') || $(this).parent().is(':disabled'));
+          that.setSelected(index, $(this).is(':selected'));
         });
-      };
-  this.$newElement.on('click', function () {
-    if (that.isDisabled()) {
-      return;
-    }
-    getPlacement($(this));
-    $drop.appendTo(that.options.container);
-    $drop.toggleClass('open', !$(this).hasClass('open'));
-    $drop.append(that.$menu);
-  });
-  $(window).resize(function () {
-    getPlacement(that.$newElement);
-  });
-  $(window).on('scroll', function () {
-    getPlacement(that.$newElement);
-  });
-  $('html').on('click', function (e) {
-    if ($(e.target).closest(that.$newElement).length < 1) {
-      $drop.removeClass('open');
-    }
-  });
-},
+      }
 
-setSelected: function (index, selected) {
-  this.findLis();
-  this.$lis.filter('[data-original-index="' + index + '"]').toggleClass('selected', selected);
-},
+      this.tabIndex();
+      var notDisabled = this.options.hideDisabled ? ':not([disabled])' : '';
+      var selectedItems = this.$element.find('option:selected' + notDisabled).map(function () {
+        var $this = $(this);
+        var icon = $this.data('icon') && that.options.showIcon ? '<i class="' + that.options.iconBase + ' ' + $this.data('icon') + '"></i> ' : '';
+        var subtext;
+        if (that.options.showSubtext && $this.attr('data-subtext') && !that.multiple) {
+          subtext = ' <small class="text-muted">' + $this.data('subtext') + '</small>';
+        } else {
+          subtext = '';
+        }
+        if (typeof $this.attr('title') !== 'undefined') {
+          return $this.attr('title');
+        } else if ($this.data('content') && that.options.showContent) {
+          return $this.data('content');
+        } else {
+          return icon + $this.html() + subtext;
+        }
+      }).toArray();
 
-setDisabled: function (index, disabled) {
-  this.findLis();
-  if (disabled) {
-    this.$lis.filter('[data-original-index="' + index + '"]').addClass('disabled').find('a').attr('href', '#').attr('tabindex', -1);
-  } else {
-    this.$lis.filter('[data-original-index="' + index + '"]').removeClass('disabled').find('a').removeAttr('href').attr('tabindex', 0);
-  }
-},
+      //Fixes issue in IE10 occurring when no default option is selected and at least one option is disabled
+      //Convert all the values into a comma delimited string
+      var title = !this.multiple ? selectedItems[0] : selectedItems.join(this.options.multipleSeparator);
 
-isDisabled: function () {
-  return this.$element.is(':disabled');
-},
+      //If this is multi select, and the selectText type is count, the show 1 of 2 selected etc..
+      if (this.multiple && this.options.selectedTextFormat.indexOf('count') > -1) {
+        var max = this.options.selectedTextFormat.split('>');
+        if ((max.length > 1 && selectedItems.length > max[1]) || (max.length == 1 && selectedItems.length >= 2)) {
+          notDisabled = this.options.hideDisabled ? ', [disabled]' : '';
+          var totalCount = this.$element.find('option').not('[data-divider="true"], [data-hidden="true"]' + notDisabled).length,
+              tr8nText = (typeof this.options.countSelectedText === 'function') ? this.options.countSelectedText(selectedItems.length, totalCount) : this.options.countSelectedText;
+          title = tr8nText.replace('{0}', selectedItems.length.toString()).replace('{1}', totalCount.toString());
+        }
+      }
 
-checkDisabled: function () {
-  var that = this;
+      if (this.options.title == undefined) {
+        this.options.title = this.$element.attr('title');
+      }
 
-  if (this.isDisabled()) {
-    this.$button.addClass('disabled').attr('tabindex', -1);
-  } else {
-    if (this.$button.hasClass('disabled')) {
-      this.$button.removeClass('disabled');
-    }
+      if (this.options.selectedTextFormat == 'static') {
+        title = this.options.title;
+      }
 
-    if (this.$button.attr('tabindex') == -1) {
-      if (!this.$element.data('tabindex')) this.$button.removeAttr('tabindex');
-    }
-  }
+      //If we dont have a title, then use the default, or if nothing is set at all, use the not selected text
+      if (!title) {
+        title = typeof this.options.title !== 'undefined' ? this.options.title : this.options.noneSelectedText;
+      }
 
-  this.$button.click(function () {
-    return !that.isDisabled();
-  });
-},
+      //strip all html-tags and trim the result
+      this.$button.attr('title', $.trim(title.replace(/<[^>]*>?/g, '')));
+      this.$newElement.find('.filter-option').html(title);
+    },
 
-tabIndex: function () {
-  if (this.$element.is('[tabindex]')) {
-    this.$element.data('tabindex', this.$element.attr('tabindex'));
-    this.$button.attr('tabindex', this.$element.data('tabindex'));
-  }
-},
+    /**
+     * @param [style]
+     * @param [status]
+     */
+    setStyle: function (style, status) {
+      if (this.$element.attr('class')) {
+        this.$newElement.addClass(this.$element.attr('class').replace(/selectpicker|mobile-device|validate\[.*\]/gi, ''));
+      }
 
-clickListener: function () {
-  var that = this;
+      var buttonClass = style ? style : this.options.style;
 
-  this.$newElement.on('touchstart.dropdown', '.dropdown-menu', function (e) {
-    e.stopPropagation();
-  });
+      if (status == 'add') {
+        this.$button.addClass(buttonClass);
+      } else if (status == 'remove') {
+        this.$button.removeClass(buttonClass);
+      } else {
+        this.$button.removeClass(this.options.style);
+        this.$button.addClass(buttonClass);
+      }
+    },
 
-  this.$newElement.on('click', function () {
-    that.setSize();
-    if (!that.options.liveSearch && !that.multiple) {
-      setTimeout(function () {
-        that.$menu.find('.selected a').focus();
-      }, 10);
-    }
-  });
+    liHeight: function () {
+      if (this.options.size === false) return;
 
-  this.$menu.on('click', 'li a', function (e) {
-    var $this = $(this),
-        clickedIndex = $this.parent().data('originalIndex'),
-        prevValue = that.$element.val(),
-        prevIndex = that.$element.prop('selectedIndex');
+      var $selectClone = this.$menu.parent().clone().children('.dropdown-toggle').prop('autofocus', false).end().appendTo('body'),
+          $menuClone = $selectClone.addClass('open').children('.dropdown-menu'),
+          liHeight = $menuClone.find('li').not('.divider').not('.dropdown-header').filter(':visible').children('a').outerHeight(),
+          headerHeight = this.options.header ? $menuClone.find('.popover-title').outerHeight() : 0,
+          searchHeight = this.options.liveSearch ? $menuClone.find('.bs-searchbox').outerHeight() : 0,
+          actionsHeight = this.options.actionsBox ? $menuClone.find('.bs-actionsbox').outerHeight() : 0,
+          doneButtonHeight = this.multiple ? $menuClone.find('.bs-donebutton').outerHeight() : 0;
 
-    // Don't close on multi choice menu
-    if (that.multiple) {
-      e.stopPropagation();
-    }
+      $selectClone.remove();
 
-    e.preventDefault();
+      this.$newElement
+          .data('liHeight', liHeight)
+          .data('headerHeight', headerHeight)
+          .data('searchHeight', searchHeight)
+          .data('actionsHeight', actionsHeight)
+          .data('doneButtonHeight', doneButtonHeight);
+    },
 
-    //Don't run if we have been disabled
-    if (!that.isDisabled() && !$this.parent().hasClass('disabled')) {
-      var $options = that.$element.find('option'),
-          $option = $options.eq(clickedIndex),
-          state = $option.prop('selected'),
-          $optgroup = $option.parent('optgroup'),
-          maxOptions = that.options.maxOptions,
-          maxOptionsGrp = $optgroup.data('maxOptions') || false;
+    setSize: function () {
+      this.findLis();
+      var that = this,
+          menu = this.$menu,
+          menuInner = menu.find('.inner'),
+          selectHeight = this.$newElement.outerHeight(),
+          liHeight = this.$newElement.data('liHeight'),
+          headerHeight = this.$newElement.data('headerHeight'),
+          searchHeight = this.$newElement.data('searchHeight'),
+          actionsHeight = this.$newElement.data('actionsHeight'),
+          doneButtonHeight = this.$newElement.data('doneButtonHeight'),
+          divHeight = this.$lis.filter('.divider').outerHeight(true),
+          menuPadding = parseInt(menu.css('padding-top')) +
+              parseInt(menu.css('padding-bottom')) +
+              parseInt(menu.css('border-top-width')) +
+              parseInt(menu.css('border-bottom-width')),
+          notDisabled = this.options.hideDisabled ? ', .disabled' : '',
+          $window = $(window),
+          menuExtras = menuPadding + parseInt(menu.css('margin-top')) + parseInt(menu.css('margin-bottom')) + 2,
+          menuHeight,
+          selectOffsetTop,
+          selectOffsetBot,
+          posVert = function () {
+            // JQuery defines a scrollTop function, but in pure JS it's a property
+            //noinspection JSValidateTypes
+            selectOffsetTop = that.$newElement.offset().top - $window.scrollTop();
+            selectOffsetBot = $window.height() - selectOffsetTop - selectHeight;
+          };
+      posVert();
+      if (this.options.header) menu.css('padding-top', 0);
 
-      if (!that.multiple) { // Deselect all others if not multi select box
-        $options.prop('selected', false);
-        $option.prop('selected', true);
-        that.$menu.find('.selected').removeClass('selected');
-        that.setSelected(clickedIndex, true);
-      } else { // Toggle the one we have chosen if we are multi select.
-        $option.prop('selected', !state);
-        that.setSelected(clickedIndex, !state);
-        $this.blur();
+      if (this.options.size == 'auto') {
+        var getSize = function () {
+          var minHeight,
+              lisVis = that.$lis.not('.hidden');
 
-        if (maxOptions !== false || maxOptionsGrp !== false) {
-          var maxReached = maxOptions < $options.filter(':selected').length,
-              maxReachedGrp = maxOptionsGrp < $optgroup.find('option:selected').length;
+          posVert();
+          menuHeight = selectOffsetBot - menuExtras;
 
-          if ((maxOptions && maxReached) || (maxOptionsGrp && maxReachedGrp)) {
-            if (maxOptions && maxOptions == 1) {
-              $options.prop('selected', false);
-              $option.prop('selected', true);
-              that.$menu.find('.selected').removeClass('selected');
-              that.setSelected(clickedIndex, true);
-            } else if (maxOptionsGrp && maxOptionsGrp == 1) {
-              $optgroup.find('option:selected').prop('selected', false);
-              $option.prop('selected', true);
-              var optgroupID = $this.data('optgroup');
+          if (that.options.dropupAuto) {
+            that.$newElement.toggleClass('dropup', selectOffsetTop > selectOffsetBot && (menuHeight - menuExtras) < menu.height());
+          }
+          if (that.$newElement.hasClass('dropup')) {
+            menuHeight = selectOffsetTop - menuExtras;
+          }
 
-              that.$menu.find('.selected').has('a[data-optgroup="' + optgroupID + '"]').removeClass('selected');
+          if ((lisVis.length + lisVis.filter('.dropdown-header').length) > 3) {
+            minHeight = liHeight * 3 + menuExtras - 2;
+          } else {
+            minHeight = 0;
+          }
 
-              that.setSelected(clickedIndex, true);
+          menu.css({
+            'max-height': menuHeight + 'px',
+            'overflow': 'hidden',
+            'min-height': minHeight + headerHeight + searchHeight + actionsHeight + doneButtonHeight + 'px'
+          });
+          menuInner.css({
+            'max-height': menuHeight - headerHeight - searchHeight - actionsHeight - doneButtonHeight - menuPadding + 'px',
+            'overflow-y': 'auto',
+            'min-height': Math.max(minHeight - menuPadding, 0) + 'px'
+          });
+        };
+        getSize();
+        this.$searchbox.off('input.getSize propertychange.getSize').on('input.getSize propertychange.getSize', getSize);
+        $window.off('resize.getSize').on('resize.getSize', getSize);
+        $window.off('scroll.getSize').on('scroll.getSize', getSize);
+      } else if (this.options.size && this.options.size != 'auto' && menu.find('li' + notDisabled).length > this.options.size) {
+        var optIndex = this.$lis.not('.divider' + notDisabled).children().slice(0, this.options.size).last().parent().index();
+        var divLength = this.$lis.slice(0, optIndex + 1).filter('.divider').length;
+        menuHeight = liHeight * this.options.size + divLength * divHeight + menuPadding;
+        if (that.options.dropupAuto) {
+          //noinspection JSUnusedAssignment
+          this.$newElement.toggleClass('dropup', selectOffsetTop > selectOffsetBot && menuHeight < menu.height());
+        }
+        menu.css({
+          'max-height': menuHeight + headerHeight + searchHeight + actionsHeight + doneButtonHeight + 'px',
+          'overflow': 'hidden'
+        });
+        menuInner.css({'max-height': menuHeight - menuPadding + 'px', 'overflow-y': 'auto'});
+      }
+    },
+
+    setWidth: function () {
+      if (this.options.width == 'auto') {
+        this.$menu.css('min-width', '0');
+
+        // Get correct width if element hidden
+        var selectClone = this.$newElement.clone().appendTo('body');
+        var ulWidth = selectClone.children('.dropdown-menu').css('width');
+        var btnWidth = selectClone.css('width', 'auto').children('button').css('width');
+        selectClone.remove();
+
+        // Set width to whatever's larger, button title or longest option
+        this.$newElement.css('width', Math.max(parseInt(ulWidth), parseInt(btnWidth)) + 'px');
+      } else if (this.options.width == 'fit') {
+        // Remove inline min-width so width can be changed from 'auto'
+        this.$menu.css('min-width', '');
+        this.$newElement.css('width', '').addClass('fit-width');
+      } else if (this.options.width) {
+        // Remove inline min-width so width can be changed from 'auto'
+        this.$menu.css('min-width', '');
+        this.$newElement.css('width', this.options.width);
+      } else {
+        // Remove inline min-width/width so width can be changed
+        this.$menu.css('min-width', '');
+        this.$newElement.css('width', '');
+      }
+      // Remove fit-width class if width is changed programmatically
+      if (this.$newElement.hasClass('fit-width') && this.options.width !== 'fit') {
+        this.$newElement.removeClass('fit-width');
+      }
+    },
+
+    selectPosition: function () {
+      var that = this,
+          drop = '<div />',
+          $drop = $(drop),
+          pos,
+          actualHeight,
+          getPlacement = function ($element) {
+            $drop.addClass($element.attr('class').replace(/form-control/gi, '')).toggleClass('dropup', $element.hasClass('dropup'));
+            pos = $element.offset();
+            actualHeight = $element.hasClass('dropup') ? 0 : $element[0].offsetHeight;
+            $drop.css({
+              'top': pos.top + actualHeight,
+              'left': pos.left,
+              'width': $element[0].offsetWidth,
+              'position': 'absolute'
+            });
+          };
+      this.$newElement.on('click', function () {
+        if (that.isDisabled()) {
+          return;
+        }
+        getPlacement($(this));
+        $drop.appendTo(that.options.container);
+        $drop.toggleClass('open', !$(this).hasClass('open'));
+        $drop.append(that.$menu);
+      });
+      $(window).resize(function () {
+        getPlacement(that.$newElement);
+      });
+      $(window).on('scroll', function () {
+        getPlacement(that.$newElement);
+      });
+      $('html').on('click', function (e) {
+        if ($(e.target).closest(that.$newElement).length < 1) {
+          $drop.removeClass('open');
+        }
+      });
+    },
+
+    setSelected: function (index, selected) {
+      this.findLis();
+      this.$lis.filter('[data-original-index="' + index + '"]').toggleClass('selected', selected);
+    },
+
+    setDisabled: function (index, disabled) {
+      this.findLis();
+      if (disabled) {
+        this.$lis.filter('[data-original-index="' + index + '"]').addClass('disabled').find('a').attr('href', '#').attr('tabindex', -1);
+      } else {
+        this.$lis.filter('[data-original-index="' + index + '"]').removeClass('disabled').find('a').removeAttr('href').attr('tabindex', 0);
+      }
+    },
+
+    isDisabled: function () {
+      return this.$element.is(':disabled');
+    },
+
+    checkDisabled: function () {
+      var that = this;
+
+      if (this.isDisabled()) {
+        this.$button.addClass('disabled').attr('tabindex', -1);
+      } else {
+        if (this.$button.hasClass('disabled')) {
+          this.$button.removeClass('disabled');
+        }
+
+        if (this.$button.attr('tabindex') == -1) {
+          if (!this.$element.data('tabindex')) this.$button.removeAttr('tabindex');
+        }
+      }
+
+      this.$button.click(function () {
+        return !that.isDisabled();
+      });
+    },
+
+    tabIndex: function () {
+      if (this.$element.is('[tabindex]')) {
+        this.$element.data('tabindex', this.$element.attr('tabindex'));
+        this.$button.attr('tabindex', this.$element.data('tabindex'));
+      }
+    },
+
+    clickListener: function () {
+      var that = this;
+
+      this.$newElement.on('touchstart.dropdown', '.dropdown-menu', function (e) {
+        e.stopPropagation();
+      });
+
+      this.$newElement.on('click', function () {
+        that.setSize();
+        if (!that.options.liveSearch && !that.multiple) {
+          setTimeout(function () {
+            that.$menu.find('.selected a').focus();
+          }, 10);
+        }
+      });
+
+      this.$menu.on('click', 'li a', function (e) {
+        var $this = $(this),
+            clickedIndex = $this.parent().data('originalIndex'),
+            prevValue = that.$element.val(),
+            prevIndex = that.$element.prop('selectedIndex');
+
+        // Don't close on multi choice menu
+        if (that.multiple) {
+          e.stopPropagation();
+        }
+
+        e.preventDefault();
+
+        //Don't run if we have been disabled
+        if (!that.isDisabled() && !$this.parent().hasClass('disabled')) {
+          var $options = that.$element.find('option'),
+              $option = $options.eq(clickedIndex),
+              state = $option.prop('selected'),
+              $optgroup = $option.parent('optgroup'),
+              maxOptions = that.options.maxOptions,
+              maxOptionsGrp = $optgroup.data('maxOptions') || false;
+
+          if (!that.multiple) { // Deselect all others if not multi select box
+            $options.prop('selected', false);
+            $option.prop('selected', true);
+            that.$menu.find('.selected').removeClass('selected');
+            that.setSelected(clickedIndex, true);
+          } else { // Toggle the one we have chosen if we are multi select.
+            $option.prop('selected', !state);
+            that.setSelected(clickedIndex, !state);
+            $this.blur();
+
+            if (maxOptions !== false || maxOptionsGrp !== false) {
+              var maxReached = maxOptions < $options.filter(':selected').length,
+                  maxReachedGrp = maxOptionsGrp < $optgroup.find('option:selected').length;
+
+              if ((maxOptions && maxReached) || (maxOptionsGrp && maxReachedGrp)) {
+                if (maxOptions && maxOptions == 1) {
+                  $options.prop('selected', false);
+                  $option.prop('selected', true);
+                  that.$menu.find('.selected').removeClass('selected');
+                  that.setSelected(clickedIndex, true);
+                } else if (maxOptionsGrp && maxOptionsGrp == 1) {
+                  $optgroup.find('option:selected').prop('selected', false);
+                  $option.prop('selected', true);
+                  var optgroupID = $this.data('optgroup');
+
+                  that.$menu.find('.selected').has('a[data-optgroup="' + optgroupID + '"]').removeClass('selected');
+
+                  that.setSelected(clickedIndex, true);
+                } else {
+                  var maxOptionsArr = (typeof that.options.maxOptionsText === 'function') ?
+                          that.options.maxOptionsText(maxOptions, maxOptionsGrp) : that.options.maxOptionsText,
+                      maxTxt = maxOptionsArr[0].replace('{n}', maxOptions),
+                      maxTxtGrp = maxOptionsArr[1].replace('{n}', maxOptionsGrp),
+                      $notify = $('<div class="notify"></div>');
+                  // If {var} is set in array, replace it
+                  /** @deprecated */
+                  if (maxOptionsArr[2]) {
+                    maxTxt = maxTxt.replace('{var}', maxOptionsArr[2][maxOptions > 1 ? 0 : 1]);
+                    maxTxtGrp = maxTxtGrp.replace('{var}', maxOptionsArr[2][maxOptionsGrp > 1 ? 0 : 1]);
+                  }
+
+                  $option.prop('selected', false);
+
+                  that.$menu.append($notify);
+
+                  if (maxOptions && maxReached) {
+                    $notify.append($('<div>' + maxTxt + '</div>'));
+                    that.$element.trigger('maxReached.bs.select');
+                  }
+
+                  if (maxOptionsGrp && maxReachedGrp) {
+                    $notify.append($('<div>' + maxTxtGrp + '</div>'));
+                    that.$element.trigger('maxReachedGrp.bs.select');
+                  }
+
+                  setTimeout(function () {
+                    that.setSelected(clickedIndex, false);
+                  }, 10);
+
+                  $notify.delay(750).fadeOut(300, function () {
+                    $(this).remove();
+                  });
+                }
+              }
+            }
+          }
+
+          if (!that.multiple) {
+            that.$button.focus();
+          } else if (that.options.liveSearch) {
+            that.$searchbox.focus();
+          }
+
+          // Trigger select 'change'
+          if ((prevValue != that.$element.val() && that.multiple) || (prevIndex != that.$element.prop('selectedIndex') && !that.multiple)) {
+            that.$element.change();
+          }
+        }
+      });
+
+      this.$menu.on('click', 'li.disabled a, .popover-title, .popover-title :not(.close)', function (e) {
+        if (e.currentTarget == this) {
+          e.preventDefault();
+          e.stopPropagation();
+          if (!that.options.liveSearch) {
+            that.$button.focus();
+          } else {
+            that.$searchbox.focus();
+          }
+        }
+      });
+
+      this.$menu.on('click', 'li.divider, li.dropdown-header', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!that.options.liveSearch) {
+          that.$button.focus();
+        } else {
+          that.$searchbox.focus();
+        }
+      });
+
+      this.$menu.on('click', '.popover-title .close', function () {
+        that.$button.focus();
+      });
+
+      this.$searchbox.on('click', function (e) {
+        e.stopPropagation();
+      });
+
+
+      this.$menu.on('click', '.actions-btn', function (e) {
+        if (that.options.liveSearch) {
+          that.$searchbox.focus();
+        } else {
+          that.$button.focus();
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        if ($(this).is('.bs-select-all')) {
+          that.selectAll();
+        } else {
+          that.deselectAll();
+        }
+        that.$element.change();
+      });
+
+      this.$element.change(function () {
+        that.render(false);
+      });
+    },
+
+    liveSearchListener: function () {
+      var that = this,
+          no_results = $('<li class="no-results"></li>');
+
+      this.$newElement.on('click.dropdown.data-api touchstart.dropdown.data-api', function () {
+        that.$menu.find('.active').removeClass('active');
+        if (!!that.$searchbox.val()) {
+          that.$searchbox.val('');
+          that.$lis.not('.is-hidden').removeClass('hidden');
+          if (!!no_results.parent().length) no_results.remove();
+        }
+        if (!that.multiple) that.$menu.find('.selected').addClass('active');
+        setTimeout(function () {
+          that.$searchbox.focus();
+        }, 10);
+      });
+
+      this.$searchbox.on('click.dropdown.data-api focus.dropdown.data-api touchend.dropdown.data-api', function (e) {
+        e.stopPropagation();
+      });
+
+      this.$searchbox.on('input propertychange', function () {
+        if (that.$searchbox.val()) {
+          var $searchBase = that.$lis.not('.is-hidden').removeClass('hidden').find('a');
+          if (that.options.liveSearchNormalize) {
+            $searchBase = $searchBase.not(':a' + that._searchStyle() + '(' + normalizeToBase(that.$searchbox.val()) + ')');
+          } else {
+            $searchBase = $searchBase.not(':' + that._searchStyle() + '(' + that.$searchbox.val() + ')');
+          }
+          $searchBase.parent().addClass('hidden');
+
+          that.$lis.filter('.dropdown-header').each(function () {
+            var $this = $(this),
+                optgroup = $this.data('optgroup');
+
+            if (that.$lis.filter('[data-optgroup=' + optgroup + ']').not($this).filter(':visible').length === 0) {
+              $this.addClass('hidden');
+            }
+          });
+
+          if (!that.$menu.find('li').filter(':visible:not(.no-results)').length) {
+            if (!!no_results.parent().length) {
+              no_results.remove();
+            }
+            no_results.html(that.options.noneResultsText.replace('{0}', '"' + htmlEscape(that.$searchbox.val()) + '"')).show();
+            that.$menu.find('li').last().after(no_results);
+          } else if (!!no_results.parent().length) {
+            no_results.remove();
+          }
+
+        } else {
+          that.$lis.not('.is-hidden').removeClass('hidden');
+          if (!!no_results.parent().length) {
+            no_results.remove();
+          }
+        }
+
+        that.$menu.find('li.active').removeClass('active');
+        that.$menu.find('li').filter(':visible:not(.divider)').eq(0).addClass('active').find('a').focus();
+        $(this).focus();
+      });
+    },
+
+    _searchStyle: function () {
+      var style = 'icontains';
+      switch (this.options.liveSearchStyle) {
+        case 'begins':
+        case 'startsWith':
+          style = 'ibegins';
+          break;
+        case 'contains':
+        default:
+          break; //no need to change the default
+      }
+
+      return style;
+    },
+
+    val: function (value) {
+      if (typeof value !== 'undefined') {
+        this.$element.val(value);
+        this.render();
+
+        return this.$element;
+      } else {
+        return this.$element.val();
+      }
+    },
+
+    selectAll: function () {
+      this.findLis();
+      this.$lis.not('.divider').not('.disabled').not('.selected').filter(':visible').find('a').click();
+    },
+
+    deselectAll: function () {
+      this.findLis();
+      this.$lis.not('.divider').not('.disabled').filter('.selected').filter(':visible').find('a').click();
+    },
+
+    keydown: function (e) {
+      var $this = $(this),
+          $parent = ($this.is('input')) ? $this.parent().parent() : $this.parent(),
+          $items,
+          that = $parent.data('this'),
+          index,
+          next,
+          first,
+          last,
+          prev,
+          nextPrev,
+          prevIndex,
+          isActive,
+          keyCodeMap = {
+            32: ' ',
+            48: '0',
+            49: '1',
+            50: '2',
+            51: '3',
+            52: '4',
+            53: '5',
+            54: '6',
+            55: '7',
+            56: '8',
+            57: '9',
+            59: ';',
+            65: 'a',
+            66: 'b',
+            67: 'c',
+            68: 'd',
+            69: 'e',
+            70: 'f',
+            71: 'g',
+            72: 'h',
+            73: 'i',
+            74: 'j',
+            75: 'k',
+            76: 'l',
+            77: 'm',
+            78: 'n',
+            79: 'o',
+            80: 'p',
+            81: 'q',
+            82: 'r',
+            83: 's',
+            84: 't',
+            85: 'u',
+            86: 'v',
+            87: 'w',
+            88: 'x',
+            89: 'y',
+            90: 'z',
+            96: '0',
+            97: '1',
+            98: '2',
+            99: '3',
+            100: '4',
+            101: '5',
+            102: '6',
+            103: '7',
+            104: '8',
+            105: '9'
+          };
+
+      if (that.options.liveSearch) $parent = $this.parent().parent();
+
+      if (that.options.container) $parent = that.$menu;
+
+      $items = $('[role=menu] li a', $parent);
+
+      isActive = that.$menu.parent().hasClass('open');
+
+      if (!isActive && /([0-9]|[A-z])/.test(String.fromCharCode(e.keyCode))) {
+        if (!that.options.container) {
+          that.setSize();
+          that.$menu.parent().addClass('open');
+          isActive = true;
+        } else {
+          that.$newElement.trigger('click');
+        }
+        that.$searchbox.focus();
+      }
+
+      if (that.options.liveSearch) {
+        if (/(^9$|27)/.test(e.keyCode.toString(10)) && isActive && that.$menu.find('.active').length === 0) {
+          e.preventDefault();
+          that.$menu.parent().removeClass('open');
+          that.$button.focus();
+        }
+        $items = $('[role=menu] li:not(.divider):not(.dropdown-header):visible a', $parent);
+        if (!$this.val() && !/(38|40)/.test(e.keyCode.toString(10))) {
+          if ($items.filter('.active').length === 0) {
+            $items = that.$newElement.find('li a');
+            if (that.options.liveSearchNormalize) {
+              $items = $items.filter(':a' + that._searchStyle() + '(' + normalizeToBase(keyCodeMap[e.keyCode]) + ')');
             } else {
-              var maxOptionsArr = (typeof that.options.maxOptionsText === 'function') ?
-                      that.options.maxOptionsText(maxOptions, maxOptionsGrp) : that.options.maxOptionsText,
-                  maxTxt = maxOptionsArr[0].replace('{n}', maxOptions),
-                  maxTxtGrp = maxOptionsArr[1].replace('{n}', maxOptionsGrp),
-                  $notify = $('<div class="notify"></div>');
-              // If {var} is set in array, replace it
-              /** @deprecated */
-              if (maxOptionsArr[2]) {
-                maxTxt = maxTxt.replace('{var}', maxOptionsArr[2][maxOptions > 1 ? 0 : 1]);
-                maxTxtGrp = maxTxtGrp.replace('{var}', maxOptionsArr[2][maxOptionsGrp > 1 ? 0 : 1]);
-              }
-
-              $option.prop('selected', false);
-
-              that.$menu.append($notify);
-
-              if (maxOptions && maxReached) {
-                $notify.append($('<div>' + maxTxt + '</div>'));
-                that.$element.trigger('maxReached.bs.select');
-              }
-
-              if (maxOptionsGrp && maxReachedGrp) {
-                $notify.append($('<div>' + maxTxtGrp + '</div>'));
-                that.$element.trigger('maxReachedGrp.bs.select');
-              }
-
-              setTimeout(function () {
-                that.setSelected(clickedIndex, false);
-              }, 10);
-
-              $notify.delay(750).fadeOut(300, function () {
-                $(this).remove();
-              });
+              $items = $items.filter(':' + that._searchStyle() + '(' + keyCodeMap[e.keyCode] + ')');
             }
           }
         }
       }
 
-      if (!that.multiple) {
-        that.$button.focus();
-      } else if (that.options.liveSearch) {
-        that.$searchbox.focus();
-      }
+      if (!$items.length) return;
 
-      // Trigger select 'change'
-      if ((prevValue != that.$element.val() && that.multiple) || (prevIndex != that.$element.prop('selectedIndex') && !that.multiple)) {
-        that.$element.change();
-      }
-    }
-  });
+      if (/(38|40)/.test(e.keyCode.toString(10))) {
+        index = $items.index($items.filter(':focus'));
+        first = $items.parent(':not(.disabled):visible').first().index();
+        last = $items.parent(':not(.disabled):visible').last().index();
+        next = $items.eq(index).parent().nextAll(':not(.disabled):visible').eq(0).index();
+        prev = $items.eq(index).parent().prevAll(':not(.disabled):visible').eq(0).index();
+        nextPrev = $items.eq(next).parent().prevAll(':not(.disabled):visible').eq(0).index();
 
-  this.$menu.on('click', 'li.disabled a, .popover-title, .popover-title :not(.close)', function (e) {
-    if (e.currentTarget == this) {
-      e.preventDefault();
-      e.stopPropagation();
-      if (!that.options.liveSearch) {
-        that.$button.focus();
-      } else {
-        that.$searchbox.focus();
-      }
-    }
-  });
-
-  this.$menu.on('click', 'li.divider, li.dropdown-header', function (e) {
-    e.preventDefault();
-    e.stopPropagation();
-    if (!that.options.liveSearch) {
-      that.$button.focus();
-    } else {
-      that.$searchbox.focus();
-    }
-  });
-
-  this.$menu.on('click', '.popover-title .close', function () {
-    that.$button.focus();
-  });
-
-  this.$searchbox.on('click', function (e) {
-    e.stopPropagation();
-  });
-
-
-  this.$menu.on('click', '.actions-btn', function (e) {
-    if (that.options.liveSearch) {
-      that.$searchbox.focus();
-    } else {
-      that.$button.focus();
-    }
-
-    e.preventDefault();
-    e.stopPropagation();
-
-    if ($(this).is('.bs-select-all')) {
-      that.selectAll();
-    } else {
-      that.deselectAll();
-    }
-    that.$element.change();
-  });
-
-  this.$element.change(function () {
-    that.render(false);
-  });
-},
-
-liveSearchListener: function () {
-  var that = this,
-      no_results = $('<li class="no-results"></li>');
-
-  this.$newElement.on('click.dropdown.data-api touchstart.dropdown.data-api', function () {
-    that.$menu.find('.active').removeClass('active');
-    if (!!that.$searchbox.val()) {
-      that.$searchbox.val('');
-      that.$lis.not('.is-hidden').removeClass('hidden');
-      if (!!no_results.parent().length) no_results.remove();
-    }
-    if (!that.multiple) that.$menu.find('.selected').addClass('active');
-    setTimeout(function () {
-      that.$searchbox.focus();
-    }, 10);
-  });
-
-  this.$searchbox.on('click.dropdown.data-api focus.dropdown.data-api touchend.dropdown.data-api', function (e) {
-    e.stopPropagation();
-  });
-
-  this.$searchbox.on('input propertychange', function () {
-    if (that.$searchbox.val()) {
-      var $searchBase = that.$lis.not('.is-hidden').removeClass('hidden').find('a');
-      if (that.options.liveSearchNormalize) {
-        $searchBase = $searchBase.not(':a' + that._searchStyle() + '(' + normalizeToBase(that.$searchbox.val()) + ')');
-      } else {
-        $searchBase = $searchBase.not(':' + that._searchStyle() + '(' + that.$searchbox.val() + ')');
-      }
-      $searchBase.parent().addClass('hidden');
-
-      that.$lis.filter('.dropdown-header').each(function () {
-        var $this = $(this),
-            optgroup = $this.data('optgroup');
-
-        if (that.$lis.filter('[data-optgroup=' + optgroup + ']').not($this).filter(':visible').length === 0) {
-          $this.addClass('hidden');
+        if (that.options.liveSearch) {
+          $items.each(function (i) {
+            if ($(this).is(':not(.disabled)')) {
+              $(this).data('index', i);
+            }
+          });
+          index = $items.index($items.filter('.active'));
+          first = $items.filter(':not(.disabled):visible').first().data('index');
+          last = $items.filter(':not(.disabled):visible').last().data('index');
+          next = $items.eq(index).nextAll(':not(.disabled):visible').eq(0).data('index');
+          prev = $items.eq(index).prevAll(':not(.disabled):visible').eq(0).data('index');
+          nextPrev = $items.eq(next).prevAll(':not(.disabled):visible').eq(0).data('index');
         }
-      });
 
-      if (!that.$menu.find('li').filter(':visible:not(.no-results)').length) {
-        if (!!no_results.parent().length) {
-          no_results.remove();
+        prevIndex = $this.data('prevIndex');
+
+        if (e.keyCode == 38) {
+          if (that.options.liveSearch) index -= 1;
+          if (index != nextPrev && index > prev) index = prev;
+          if (index < first) index = first;
+          if (index == prevIndex) index = last;
         }
-        no_results.html(that.options.noneResultsText.replace('{0}', '"' + htmlEscape(that.$searchbox.val()) + '"')).show();
-        that.$menu.find('li').last().after(no_results);
-      } else if (!!no_results.parent().length) {
-        no_results.remove();
-      }
 
-    } else {
-      that.$lis.not('.is-hidden').removeClass('hidden');
-      if (!!no_results.parent().length) {
-        no_results.remove();
-      }
-    }
+        if (e.keyCode == 40) {
+          if (that.options.liveSearch) index += 1;
+          if (index == -1) index = 0;
+          if (index != nextPrev && index < next) index = next;
+          if (index > last) index = last;
+          if (index == prevIndex) index = first;
+        }
 
-    that.$menu.find('li.active').removeClass('active');
-    that.$menu.find('li').filter(':visible:not(.divider)').eq(0).addClass('active').find('a').focus();
-    $(this).focus();
-  });
-},
+        $this.data('prevIndex', index);
 
-_searchStyle: function () {
-  var style = 'icontains';
-  switch (this.options.liveSearchStyle) {
-    case 'begins':
-    case 'startsWith':
-      style = 'ibegins';
-      break;
-    case 'contains':
-    default:
-      break; //no need to change the default
-  }
-
-  return style;
-},
-
-val: function (value) {
-  if (typeof value !== 'undefined') {
-    this.$element.val(value);
-    this.render();
-
-    return this.$element;
-  } else {
-    return this.$element.val();
-  }
-},
-
-selectAll: function () {
-  this.findLis();
-  this.$lis.not('.divider').not('.disabled').not('.selected').filter(':visible').find('a').click();
-},
-
-deselectAll: function () {
-  this.findLis();
-  this.$lis.not('.divider').not('.disabled').filter('.selected').filter(':visible').find('a').click();
-},
-
-keydown: function (e) {
-  var $this = $(this),
-      $parent = ($this.is('input')) ? $this.parent().parent() : $this.parent(),
-      $items,
-      that = $parent.data('this'),
-      index,
-      next,
-      first,
-      last,
-      prev,
-      nextPrev,
-      prevIndex,
-      isActive,
-      keyCodeMap = {
-        32: ' ',
-        48: '0',
-        49: '1',
-        50: '2',
-        51: '3',
-        52: '4',
-        53: '5',
-        54: '6',
-        55: '7',
-        56: '8',
-        57: '9',
-        59: ';',
-        65: 'a',
-        66: 'b',
-        67: 'c',
-        68: 'd',
-        69: 'e',
-        70: 'f',
-        71: 'g',
-        72: 'h',
-        73: 'i',
-        74: 'j',
-        75: 'k',
-        76: 'l',
-        77: 'm',
-        78: 'n',
-        79: 'o',
-        80: 'p',
-        81: 'q',
-        82: 'r',
-        83: 's',
-        84: 't',
-        85: 'u',
-        86: 'v',
-        87: 'w',
-        88: 'x',
-        89: 'y',
-        90: 'z',
-        96: '0',
-        97: '1',
-        98: '2',
-        99: '3',
-        100: '4',
-        101: '5',
-        102: '6',
-        103: '7',
-        104: '8',
-        105: '9'
-      };
-
-  if (that.options.liveSearch) $parent = $this.parent().parent();
-
-  if (that.options.container) $parent = that.$menu;
-
-  $items = $('[role=menu] li a', $parent);
-
-  isActive = that.$menu.parent().hasClass('open');
-
-  if (!isActive && /([0-9]|[A-z])/.test(String.fromCharCode(e.keyCode))) {
-    if (!that.options.container) {
-      that.setSize();
-      that.$menu.parent().addClass('open');
-      isActive = true;
-    } else {
-      that.$newElement.trigger('click');
-    }
-    that.$searchbox.focus();
-  }
-
-  if (that.options.liveSearch) {
-    if (/(^9$|27)/.test(e.keyCode.toString(10)) && isActive && that.$menu.find('.active').length === 0) {
-      e.preventDefault();
-      that.$menu.parent().removeClass('open');
-      that.$button.focus();
-    }
-    $items = $('[role=menu] li:not(.divider):not(.dropdown-header):visible a', $parent);
-    if (!$this.val() && !/(38|40)/.test(e.keyCode.toString(10))) {
-      if ($items.filter('.active').length === 0) {
-        $items = that.$newElement.find('li a');
-        if (that.options.liveSearchNormalize) {
-          $items = $items.filter(':a' + that._searchStyle() + '(' + normalizeToBase(keyCodeMap[e.keyCode]) + ')');
+        if (!that.options.liveSearch) {
+          $items.eq(index).focus();
         } else {
-          $items = $items.filter(':' + that._searchStyle() + '(' + keyCodeMap[e.keyCode] + ')');
+          e.preventDefault();
+          if (!$this.is('.dropdown-toggle')) {
+            $items.removeClass('active');
+            $items.eq(index).addClass('active').find('a').focus();
+            $this.focus();
+          }
         }
-      }
-    }
-  }
 
-  if (!$items.length) return;
+      } else if (!$this.is('input')) {
+        var keyIndex = [],
+            count,
+            prevKey;
 
-  if (/(38|40)/.test(e.keyCode.toString(10))) {
-    index = $items.index($items.filter(':focus'));
-    first = $items.parent(':not(.disabled):visible').first().index();
-    last = $items.parent(':not(.disabled):visible').last().index();
-    next = $items.eq(index).parent().nextAll(':not(.disabled):visible').eq(0).index();
-    prev = $items.eq(index).parent().prevAll(':not(.disabled):visible').eq(0).index();
-    nextPrev = $items.eq(next).parent().prevAll(':not(.disabled):visible').eq(0).index();
+        $items.each(function () {
+          if ($(this).parent().is(':not(.disabled)')) {
+            if ($.trim($(this).text().toLowerCase()).substring(0, 1) == keyCodeMap[e.keyCode]) {
+              keyIndex.push($(this).parent().index());
+            }
+          }
+        });
 
-    if (that.options.liveSearch) {
-      $items.each(function (i) {
-        if ($(this).is(':not(.disabled)')) {
-          $(this).data('index', i);
+        count = $(document).data('keycount');
+        count++;
+        $(document).data('keycount', count);
+
+        prevKey = $.trim($(':focus').text().toLowerCase()).substring(0, 1);
+
+        if (prevKey != keyCodeMap[e.keyCode]) {
+          count = 1;
+          $(document).data('keycount', count);
+        } else if (count >= keyIndex.length) {
+          $(document).data('keycount', 0);
+          if (count > keyIndex.length) count = 1;
         }
-      });
-      index = $items.index($items.filter('.active'));
-      first = $items.filter(':not(.disabled):visible').first().data('index');
-      last = $items.filter(':not(.disabled):visible').last().data('index');
-      next = $items.eq(index).nextAll(':not(.disabled):visible').eq(0).data('index');
-      prev = $items.eq(index).prevAll(':not(.disabled):visible').eq(0).data('index');
-      nextPrev = $items.eq(next).prevAll(':not(.disabled):visible').eq(0).data('index');
-    }
 
-    prevIndex = $this.data('prevIndex');
-
-    if (e.keyCode == 38) {
-      if (that.options.liveSearch) index -= 1;
-      if (index != nextPrev && index > prev) index = prev;
-      if (index < first) index = first;
-      if (index == prevIndex) index = last;
-    }
-
-    if (e.keyCode == 40) {
-      if (that.options.liveSearch) index += 1;
-      if (index == -1) index = 0;
-      if (index != nextPrev && index < next) index = next;
-      if (index > last) index = last;
-      if (index == prevIndex) index = first;
-    }
-
-    $this.data('prevIndex', index);
-
-    if (!that.options.liveSearch) {
-      $items.eq(index).focus();
-    } else {
-      e.preventDefault();
-      if (!$this.is('.dropdown-toggle')) {
-        $items.removeClass('active');
-        $items.eq(index).addClass('active').find('a').focus();
-        $this.focus();
+        $items.eq(keyIndex[count - 1]).focus();
       }
+
+      // Select focused option if "Enter", "Spacebar" or "Tab" (when selectOnTab is true) are pressed inside the menu.
+      if ((/(13|32)/.test(e.keyCode.toString(10)) || (/(^9$)/.test(e.keyCode.toString(10)) && that.options.selectOnTab)) && isActive) {
+        if (!/(32)/.test(e.keyCode.toString(10))) e.preventDefault();
+        if (!that.options.liveSearch) {
+          var elem = $(':focus');
+          elem.click();
+          // Bring back focus for multiselects
+          elem.focus();
+          // Prevent screen from scrolling if the user hit the spacebar
+          e.preventDefault();
+        } else if (!/(32)/.test(e.keyCode.toString(10))) {
+          that.$menu.find('.active a').click();
+          $this.focus();
+        }
+        $(document).data('keycount', 0);
+      }
+
+      if ((/(^9$|27)/.test(e.keyCode.toString(10)) && isActive && (that.multiple || that.options.liveSearch)) || (/(27)/.test(e.keyCode.toString(10)) && !isActive)) {
+        that.$menu.parent().removeClass('open');
+        that.$button.focus();
+      }
+    },
+
+    mobile: function () {
+      this.$element.addClass('mobile-device').appendTo(this.$newElement);
+      if (this.options.container) this.$menu.hide();
+    },
+
+    refresh: function () {
+      this.$lis = null;
+      this.reloadLi();
+      this.render();
+      this.setWidth();
+      this.setStyle();
+      this.checkDisabled();
+      this.liHeight();
+    },
+
+    hide: function () {
+      this.$newElement.hide();
+    },
+
+    show: function () {
+      this.$newElement.show();
+    },
+
+    remove: function () {
+      this.$newElement.remove();
+      this.$element.remove();
     }
+  };
 
-  } else if (!$this.is('input')) {
-    var keyIndex = [],
-        count,
-        prevKey;
+  // SELECTPICKER PLUGIN DEFINITION
+  // ==============================
+  function Plugin(option, event) {
+    // get the args of the outer function..
+    var args = arguments;
+    // The arguments of the function are explicitly re-defined from the argument list, because the shift causes them
+    // to get lost/corrupted in android 2.3 and IE9 #715 #775
+    var _option = option,
+        _event = event;
+    [].shift.apply(args);
 
-    $items.each(function () {
-      if ($(this).parent().is(':not(.disabled)')) {
-        if ($.trim($(this).text().toLowerCase()).substring(0, 1) == keyCodeMap[e.keyCode]) {
-          keyIndex.push($(this).parent().index());
+    var value;
+    var chain = this.each(function () {
+      var $this = $(this);
+      if ($this.is('select')) {
+        var data = $this.data('selectpicker'),
+            options = typeof _option == 'object' && _option;
+
+        if (!data) {
+          var config = $.extend({}, Selectpicker.DEFAULTS, $.fn.selectpicker.defaults || {}, $this.data(), options);
+          $this.data('selectpicker', (data = new Selectpicker(this, config, _event)));
+        } else if (options) {
+          for (var i in options) {
+            if (options.hasOwnProperty(i)) {
+              data.options[i] = options[i];
+            }
+          }
+        }
+
+        if (typeof _option == 'string') {
+          if (data[_option] instanceof Function) {
+            value = data[_option].apply(data, args);
+          } else {
+            value = data.options[_option];
+          }
         }
       }
     });
 
-    count = $(document).data('keycount');
-    count++;
-    $(document).data('keycount', count);
-
-    prevKey = $.trim($(':focus').text().toLowerCase()).substring(0, 1);
-
-    if (prevKey != keyCodeMap[e.keyCode]) {
-      count = 1;
-      $(document).data('keycount', count);
-    } else if (count >= keyIndex.length) {
-      $(document).data('keycount', 0);
-      if (count > keyIndex.length) count = 1;
-    }
-
-    $items.eq(keyIndex[count - 1]).focus();
-  }
-
-  // Select focused option if "Enter", "Spacebar" or "Tab" (when selectOnTab is true) are pressed inside the menu.
-  if ((/(13|32)/.test(e.keyCode.toString(10)) || (/(^9$)/.test(e.keyCode.toString(10)) && that.options.selectOnTab)) && isActive) {
-    if (!/(32)/.test(e.keyCode.toString(10))) e.preventDefault();
-    if (!that.options.liveSearch) {
-      var elem = $(':focus');
-      elem.click();
-      // Bring back focus for multiselects
-      elem.focus();
-      // Prevent screen from scrolling if the user hit the spacebar
-      e.preventDefault();
-    } else if (!/(32)/.test(e.keyCode.toString(10))) {
-      that.$menu.find('.active a').click();
-      $this.focus();
-    }
-    $(document).data('keycount', 0);
-  }
-
-  if ((/(^9$|27)/.test(e.keyCode.toString(10)) && isActive && (that.multiple || that.options.liveSearch)) || (/(27)/.test(e.keyCode.toString(10)) && !isActive)) {
-    that.$menu.parent().removeClass('open');
-    that.$button.focus();
-  }
-},
-
-mobile: function () {
-  this.$element.addClass('mobile-device').appendTo(this.$newElement);
-  if (this.options.container) this.$menu.hide();
-},
-
-refresh: function () {
-  this.$lis = null;
-  this.reloadLi();
-  this.render();
-  this.setWidth();
-  this.setStyle();
-  this.checkDisabled();
-  this.liHeight();
-},
-
-hide: function () {
-  this.$newElement.hide();
-},
-
-show: function () {
-  this.$newElement.show();
-},
-
-remove: function () {
-  this.$newElement.remove();
-  this.$element.remove();
-}
-};
-
-// SELECTPICKER PLUGIN DEFINITION
-// ==============================
-function Plugin(option, event) {
-// get the args of the outer function..
-var args = arguments;
-// The arguments of the function are explicitly re-defined from the argument list, because the shift causes them
-// to get lost/corrupted in android 2.3 and IE9 #715 #775
-var _option = option,
-    _event = event;
-[].shift.apply(args);
-
-var value;
-var chain = this.each(function () {
-  var $this = $(this);
-  if ($this.is('select')) {
-    var data = $this.data('selectpicker'),
-        options = typeof _option == 'object' && _option;
-
-    if (!data) {
-      var config = $.extend({}, Selectpicker.DEFAULTS, $.fn.selectpicker.defaults || {}, $this.data(), options);
-      $this.data('selectpicker', (data = new Selectpicker(this, config, _event)));
-    } else if (options) {
-      for (var i in options) {
-        if (options.hasOwnProperty(i)) {
-          data.options[i] = options[i];
-        }
-      }
-    }
-
-    if (typeof _option == 'string') {
-      if (data[_option] instanceof Function) {
-        value = data[_option].apply(data, args);
-      } else {
-        value = data.options[_option];
-      }
+    if (typeof value !== 'undefined') {
+      //noinspection JSUnusedAssignment
+      return value;
+    } else {
+      return chain;
     }
   }
-});
 
-if (typeof value !== 'undefined') {
-  //noinspection JSUnusedAssignment
-  return value;
-} else {
-  return chain;
-}
-}
+  var old = $.fn.selectpicker;
+  $.fn.selectpicker = Plugin;
+  $.fn.selectpicker.Constructor = Selectpicker;
 
-var old = $.fn.selectpicker;
-$.fn.selectpicker = Plugin;
-$.fn.selectpicker.Constructor = Selectpicker;
+  // SELECTPICKER NO CONFLICT
+  // ========================
+  $.fn.selectpicker.noConflict = function () {
+    $.fn.selectpicker = old;
+    return this;
+  };
 
-// SELECTPICKER NO CONFLICT
-// ========================
-$.fn.selectpicker.noConflict = function () {
-$.fn.selectpicker = old;
-return this;
-};
+  $(document)
+      .data('keycount', 0)
+      .on('keydown', '.bootstrap-select [data-toggle=dropdown], .bootstrap-select [role=menu], .bs-searchbox input', Selectpicker.prototype.keydown)
+      .on('focusin.modal', '.bootstrap-select [data-toggle=dropdown], .bootstrap-select [role=menu], .bs-searchbox input', function (e) {
+        e.stopPropagation();
+      });
 
-$(document)
-  .data('keycount', 0)
-  .on('keydown', '.bootstrap-select [data-toggle=dropdown], .bootstrap-select [role=menu], .bs-searchbox input', Selectpicker.prototype.keydown)
-  .on('focusin.modal', '.bootstrap-select [data-toggle=dropdown], .bootstrap-select [role=menu], .bs-searchbox input', function (e) {
-    e.stopPropagation();
+  // SELECTPICKER DATA-API
+  // =====================
+  $(window).on('load.bs.select.data-api', function () {
+    $('.selectpicker').each(function () {
+      var $selectpicker = $(this);
+      Plugin.call($selectpicker, $selectpicker.data());
+    })
   });
-
-// SELECTPICKER DATA-API
-// =====================
-$(window).on('load.bs.select.data-api', function () {
-$('.selectpicker').each(function () {
-  var $selectpicker = $(this);
-  Plugin.call($selectpicker, $selectpicker.data());
-})
-});

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1,1373 +1,1373 @@
-(function ($) {
-  'use strict';
+'use strict';
 
-  //<editor-fold desc="Shims">
-  if (!String.prototype.includes) {
-    (function () {
-      'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
-      var toString = {}.toString;
-      var defineProperty = (function () {
-        // IE 8 only supports `Object.defineProperty` on DOM elements
-        try {
-          var object = {};
-          var $defineProperty = Object.defineProperty;
-          var result = $defineProperty(object, object, object) && $defineProperty;
-        } catch (error) {
-        }
-        return result;
-      }());
-      var indexOf = ''.indexOf;
-      var includes = function (search) {
-        if (this == null) {
-          throw TypeError();
-        }
-        var string = String(this);
-        if (search && toString.call(search) == '[object RegExp]') {
-          throw TypeError();
-        }
-        var stringLength = string.length;
-        var searchString = String(search);
-        var searchLength = searchString.length;
-        var position = arguments.length > 1 ? arguments[1] : undefined;
-        // `ToInteger`
-        var pos = position ? Number(position) : 0;
-        if (pos != pos) { // better `isNaN`
-          pos = 0;
-        }
-        var start = Math.min(Math.max(pos, 0), stringLength);
-        // Avoid the `indexOf` call if no match is possible
-        if (searchLength + start > stringLength) {
-          return false;
-        }
-        return indexOf.call(string, searchString, pos) != -1;
-      };
-      if (defineProperty) {
-        defineProperty(String.prototype, 'includes', {
-          'value': includes,
-          'configurable': true,
-          'writable': true
-        });
-      } else {
-        String.prototype.includes = includes;
+var $ = require('jQuery');
+
+//<editor-fold desc="Shims">
+if (!String.prototype.includes) {
+(function () {
+  'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
+  var toString = {}.toString;
+  var defineProperty = (function () {
+    // IE 8 only supports `Object.defineProperty` on DOM elements
+    try {
+      var object = {};
+      var $defineProperty = Object.defineProperty;
+      var result = $defineProperty(object, object, object) && $defineProperty;
+    } catch (error) {
+    }
+    return result;
+  }());
+  var indexOf = ''.indexOf;
+  var includes = function (search) {
+    if (this == null) {
+      throw TypeError();
+    }
+    var string = String(this);
+    if (search && toString.call(search) == '[object RegExp]') {
+      throw TypeError();
+    }
+    var stringLength = string.length;
+    var searchString = String(search);
+    var searchLength = searchString.length;
+    var position = arguments.length > 1 ? arguments[1] : undefined;
+    // `ToInteger`
+    var pos = position ? Number(position) : 0;
+    if (pos != pos) { // better `isNaN`
+      pos = 0;
+    }
+    var start = Math.min(Math.max(pos, 0), stringLength);
+    // Avoid the `indexOf` call if no match is possible
+    if (searchLength + start > stringLength) {
+      return false;
+    }
+    return indexOf.call(string, searchString, pos) != -1;
+  };
+  if (defineProperty) {
+    defineProperty(String.prototype, 'includes', {
+      'value': includes,
+      'configurable': true,
+      'writable': true
+    });
+  } else {
+    String.prototype.includes = includes;
+  }
+}());
+}
+
+if (!String.prototype.startsWith) {
+(function () {
+  'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
+  var defineProperty = (function () {
+    // IE 8 only supports `Object.defineProperty` on DOM elements
+    try {
+      var object = {};
+      var $defineProperty = Object.defineProperty;
+      var result = $defineProperty(object, object, object) && $defineProperty;
+    } catch (error) {
+    }
+    return result;
+  }());
+  var toString = {}.toString;
+  var startsWith = function (search) {
+    if (this == null) {
+      throw TypeError();
+    }
+    var string = String(this);
+    if (search && toString.call(search) == '[object RegExp]') {
+      throw TypeError();
+    }
+    var stringLength = string.length;
+    var searchString = String(search);
+    var searchLength = searchString.length;
+    var position = arguments.length > 1 ? arguments[1] : undefined;
+    // `ToInteger`
+    var pos = position ? Number(position) : 0;
+    if (pos != pos) { // better `isNaN`
+      pos = 0;
+    }
+    var start = Math.min(Math.max(pos, 0), stringLength);
+    // Avoid the `indexOf` call if no match is possible
+    if (searchLength + start > stringLength) {
+      return false;
+    }
+    var index = -1;
+    while (++index < searchLength) {
+      if (string.charCodeAt(start + index) != searchString.charCodeAt(index)) {
+        return false;
       }
-    }());
+    }
+    return true;
+  };
+  if (defineProperty) {
+    defineProperty(String.prototype, 'startsWith', {
+      'value': startsWith,
+      'configurable': true,
+      'writable': true
+    });
+  } else {
+    String.prototype.startsWith = startsWith;
+  }
+}());
+}
+//</editor-fold>
+
+// Case insensitive contains search
+$.expr[':'].icontains = function (obj, index, meta) {
+var $obj = $(obj);
+var haystack = ($obj.data('tokens') || $obj.text()).toUpperCase();
+return haystack.includes(meta[3].toUpperCase());
+};
+
+// Case insensitive begins search
+$.expr[':'].ibegins = function (obj, index, meta) {
+var $obj = $(obj);
+var haystack = ($obj.data('tokens') || $obj.text()).toUpperCase();
+return haystack.startsWith(meta[3].toUpperCase());
+};
+
+// Case and accent insensitive contains search
+$.expr[':'].aicontains = function (obj, index, meta) {
+var $obj = $(obj);
+var haystack = ($obj.data('tokens') || $obj.data('normalizedText') || $obj.text()).toUpperCase();
+return haystack.includes(haystack, meta[3]);
+};
+
+// Case and accent insensitive begins search
+$.expr[':'].aibegins = function (obj, index, meta) {
+var $obj = $(obj);
+var haystack = ($obj.data('tokens') || $obj.data('normalizedText') || $obj.text()).toUpperCase();
+return haystack.startsWith(meta[3].toUpperCase());
+};
+
+/**
+* Remove all diatrics from the given text.
+* @access private
+* @param {String} text
+* @returns {String}
+*/
+function normalizeToBase(text) {
+var rExps = [
+  {re: /[\xC0-\xC6]/g, ch: "A"},
+  {re: /[\xE0-\xE6]/g, ch: "a"},
+  {re: /[\xC8-\xCB]/g, ch: "E"},
+  {re: /[\xE8-\xEB]/g, ch: "e"},
+  {re: /[\xCC-\xCF]/g, ch: "I"},
+  {re: /[\xEC-\xEF]/g, ch: "i"},
+  {re: /[\xD2-\xD6]/g, ch: "O"},
+  {re: /[\xF2-\xF6]/g, ch: "o"},
+  {re: /[\xD9-\xDC]/g, ch: "U"},
+  {re: /[\xF9-\xFC]/g, ch: "u"},
+  {re: /[\xC7-\xE7]/g, ch: "c"},
+  {re: /[\xD1]/g, ch: "N"},
+  {re: /[\xF1]/g, ch: "n"}
+];
+$.each(rExps, function () {
+  text = text.replace(this.re, this.ch);
+});
+return text;
+}
+
+
+function htmlEscape(html) {
+var escapeMap = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#x27;',
+  '`': '&#x60;'
+};
+var source = '(?:' + Object.keys(escapeMap).join('|') + ')',
+    testRegexp = new RegExp(source),
+    replaceRegexp = new RegExp(source, 'g'),
+    string = html == null ? '' : '' + html;
+return testRegexp.test(string) ? string.replace(replaceRegexp, function (match) {
+  return escapeMap[match];
+}) : string;
+}
+
+var Selectpicker = function (element, options, e) {
+if (e) {
+  e.stopPropagation();
+  e.preventDefault();
+}
+
+this.$element = $(element);
+this.$newElement = null;
+this.$button = null;
+this.$menu = null;
+this.$lis = null;
+this.options = options;
+
+// If we have no title yet, try to pull it from the html title attribute (jQuery doesnt' pick it up as it's not a
+// data-attribute)
+if (this.options.title === null) {
+  this.options.title = this.$element.attr('title');
+}
+
+//Expose public methods
+this.val = Selectpicker.prototype.val;
+this.render = Selectpicker.prototype.render;
+this.refresh = Selectpicker.prototype.refresh;
+this.setStyle = Selectpicker.prototype.setStyle;
+this.selectAll = Selectpicker.prototype.selectAll;
+this.deselectAll = Selectpicker.prototype.deselectAll;
+this.destroy = Selectpicker.prototype.remove;
+this.remove = Selectpicker.prototype.remove;
+this.show = Selectpicker.prototype.show;
+this.hide = Selectpicker.prototype.hide;
+
+this.init();
+};
+
+Selectpicker.VERSION = '1.6.3';
+
+// part of this is duplicated in i18n/defaults-en_US.js. Make sure to update both.
+Selectpicker.DEFAULTS = {
+noneSelectedText: 'Nothing selected',
+noneResultsText: 'No results matched {0}',
+countSelectedText: function (numSelected, numTotal) {
+  return (numSelected == 1) ? "{0} item selected" : "{0} items selected";
+},
+maxOptionsText: function (numAll, numGroup) {
+  return [
+    (numAll == 1) ? 'Limit reached ({n} item max)' : 'Limit reached ({n} items max)',
+    (numGroup == 1) ? 'Group limit reached ({n} item max)' : 'Group limit reached ({n} items max)'
+  ];
+},
+selectAllText: 'Select All',
+deselectAllText: 'Deselect All',
+doneButton: false,
+doneButtonText: 'Close',
+multipleSeparator: ', ',
+style: 'btn-default',
+size: 'auto',
+title: null,
+selectedTextFormat: 'values',
+width: false,
+container: false,
+hideDisabled: false,
+showSubtext: false,
+showIcon: true,
+showContent: true,
+dropupAuto: true,
+header: false,
+liveSearch: false,
+liveSearchPlaceholder: null,
+liveSearchNormalize: false,
+liveSearchStyle: 'contains',
+actionsBox: false,
+iconBase: 'glyphicon',
+tickIcon: 'glyphicon-ok',
+maxOptions: false,
+mobile: false,
+selectOnTab: false,
+dropdownAlignRight: false
+};
+
+Selectpicker.prototype = {
+
+constructor: Selectpicker,
+
+init: function () {
+  var that = this,
+      id = this.$element.attr('id');
+
+  this.$element.hide();
+  this.multiple = this.$element.prop('multiple');
+  this.autofocus = this.$element.prop('autofocus');
+  this.$newElement = this.createView();
+  this.$element.after(this.$newElement);
+  this.$menu = this.$newElement.children('.dropdown-menu');
+  this.$button = this.$newElement.children('button');
+  this.$searchbox = this.$newElement.find('input');
+
+  if (this.options.dropdownAlignRight)
+    this.$menu.addClass('dropdown-menu-right');
+
+  if (typeof id !== 'undefined') {
+    this.$button.attr('data-id', id);
+    $('label[for="' + id + '"]').click(function (e) {
+      e.preventDefault();
+      that.$button.focus();
+    });
   }
 
-  if (!String.prototype.startsWith) {
-    (function () {
-      'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
-      var defineProperty = (function () {
-        // IE 8 only supports `Object.defineProperty` on DOM elements
-        try {
-          var object = {};
-          var $defineProperty = Object.defineProperty;
-          var result = $defineProperty(object, object, object) && $defineProperty;
-        } catch (error) {
-        }
-        return result;
-      }());
-      var toString = {}.toString;
-      var startsWith = function (search) {
-        if (this == null) {
-          throw TypeError();
-        }
-        var string = String(this);
-        if (search && toString.call(search) == '[object RegExp]') {
-          throw TypeError();
-        }
-        var stringLength = string.length;
-        var searchString = String(search);
-        var searchLength = searchString.length;
-        var position = arguments.length > 1 ? arguments[1] : undefined;
-        // `ToInteger`
-        var pos = position ? Number(position) : 0;
-        if (pos != pos) { // better `isNaN`
-          pos = 0;
-        }
-        var start = Math.min(Math.max(pos, 0), stringLength);
-        // Avoid the `indexOf` call if no match is possible
-        if (searchLength + start > stringLength) {
-          return false;
-        }
-        var index = -1;
-        while (++index < searchLength) {
-          if (string.charCodeAt(start + index) != searchString.charCodeAt(index)) {
-            return false;
-          }
-        }
-        return true;
-      };
-      if (defineProperty) {
-        defineProperty(String.prototype, 'startsWith', {
-          'value': startsWith,
-          'configurable': true,
-          'writable': true
-        });
-      } else {
-        String.prototype.startsWith = startsWith;
-      }
-    }());
-  }
-  //</editor-fold>
+  this.checkDisabled();
+  this.clickListener();
+  if (this.options.liveSearch) this.liveSearchListener();
+  this.render();
+  this.liHeight();
+  this.setStyle();
+  this.setWidth();
+  if (this.options.container) this.selectPosition();
+  this.$menu.data('this', this);
+  this.$newElement.data('this', this);
+  if (this.options.mobile) this.mobile();
+},
 
-  // Case insensitive contains search
-  $.expr[':'].icontains = function (obj, index, meta) {
-    var $obj = $(obj);
-    var haystack = ($obj.data('tokens') || $obj.text()).toUpperCase();
-    return haystack.includes(meta[3].toUpperCase());
-  };
+createDropdown: function () {
+  // Options
+  // If we are multiple, then add the show-tick class by default
+  var multiple = this.multiple ? ' show-tick' : '',
+      inputGroup = this.$element.parent().hasClass('input-group') ? ' input-group-btn' : '',
+      autofocus = this.autofocus ? ' autofocus' : '';
+  // Elements
+  var header = this.options.header ? '<div class="popover-title"><button type="button" class="close" aria-hidden="true">&times;</button>' + this.options.header + '</div>' : '';
+  var searchbox = this.options.liveSearch ?
+  '<div class="bs-searchbox">' +
+  '<input type="text" class="form-control" autocomplete="off"' +
+  (null === this.options.liveSearchPlaceholder ? '' : ' placeholder="' + htmlEscape(this.options.liveSearchPlaceholder) + '"') + '>' +
+  '</div>'
+      : '';
+  var actionsbox = this.multiple && this.options.actionsBox ?
+  '<div class="bs-actionsbox">' +
+  '<div class="btn-group btn-group-sm btn-block">' +
+  '<button class="actions-btn bs-select-all btn btn-default">' +
+  this.options.selectAllText +
+  '</button>' +
+  '<button class="actions-btn bs-deselect-all btn btn-default">' +
+  this.options.deselectAllText +
+  '</button>' +
+  '</div>' +
+  '</div>'
+      : '';
+  var donebutton = this.multiple && this.options.doneButton ?
+  '<div class="bs-donebutton">' +
+  '<div class="btn-group btn-block">' +
+  '<button class="btn btn-sm btn-default">' +
+  this.options.doneButtonText +
+  '</button>' +
+  '</div>' +
+  '</div>'
+      : '';
+  var drop =
+      '<div class="btn-group bootstrap-select' + multiple + inputGroup + '">' +
+      '<button type="button" class="btn dropdown-toggle form-control selectpicker" data-toggle="dropdown"' + autofocus + '>' +
+      '<span class="filter-option pull-left"></span>&nbsp;' +
+      '<span class="caret"></span>' +
+      '</button>' +
+      '<div class="dropdown-menu open">' +
+      header +
+      searchbox +
+      actionsbox +
+      '<ul class="dropdown-menu inner selectpicker" role="menu">' +
+      '</ul>' +
+      donebutton +
+      '</div>' +
+      '</div>';
 
-  // Case insensitive begins search
-  $.expr[':'].ibegins = function (obj, index, meta) {
-    var $obj = $(obj);
-    var haystack = ($obj.data('tokens') || $obj.text()).toUpperCase();
-    return haystack.startsWith(meta[3].toUpperCase());
-  };
+  return $(drop);
+},
 
-  // Case and accent insensitive contains search
-  $.expr[':'].aicontains = function (obj, index, meta) {
-    var $obj = $(obj);
-    var haystack = ($obj.data('tokens') || $obj.data('normalizedText') || $obj.text()).toUpperCase();
-    return haystack.includes(haystack, meta[3]);
-  };
+createView: function () {
+  var $drop = this.createDropdown();
+  var $li = this.createLi();
+  $drop.find('ul').append($li);
+  return $drop;
+},
 
-  // Case and accent insensitive begins search
-  $.expr[':'].aibegins = function (obj, index, meta) {
-    var $obj = $(obj);
-    var haystack = ($obj.data('tokens') || $obj.data('normalizedText') || $obj.text()).toUpperCase();
-    return haystack.startsWith(meta[3].toUpperCase());
+reloadLi: function () {
+  //Remove all children.
+  this.destroyLi();
+  //Re build
+  var $li = this.createLi();
+  this.$menu.find('ul').append($li);
+},
+
+destroyLi: function () {
+  this.$menu.find('li').remove();
+},
+
+createLi: function () {
+  var that = this,
+      _li = [],
+      optID = 0;
+
+  // Helper functions
+  /**
+   * @param content
+   * @param [index]
+   * @param [classes]
+   * @param [optgroup]
+   * @returns {string}
+   */
+  var generateLI = function (content, index, classes, optgroup) {
+    return '<li' +
+        ((typeof classes !== 'undefined' & '' !== classes) ? ' class="' + classes + '"' : '') +
+        ((typeof index !== 'undefined' & null !== index) ? ' data-original-index="' + index + '"' : '') +
+        ((typeof optgroup !== 'undefined' & null !== optgroup) ? 'data-optgroup="' + optgroup + '"' : '') +
+        '>' + content + '</li>';
   };
 
   /**
-   * Remove all diatrics from the given text.
-   * @access private
-   * @param {String} text
-   * @returns {String}
+   * @param text
+   * @param [classes]
+   * @param [inline]
+   * @param [tokens]
+   * @returns {string}
    */
-  function normalizeToBase(text) {
-    var rExps = [
-      {re: /[\xC0-\xC6]/g, ch: "A"},
-      {re: /[\xE0-\xE6]/g, ch: "a"},
-      {re: /[\xC8-\xCB]/g, ch: "E"},
-      {re: /[\xE8-\xEB]/g, ch: "e"},
-      {re: /[\xCC-\xCF]/g, ch: "I"},
-      {re: /[\xEC-\xEF]/g, ch: "i"},
-      {re: /[\xD2-\xD6]/g, ch: "O"},
-      {re: /[\xF2-\xF6]/g, ch: "o"},
-      {re: /[\xD9-\xDC]/g, ch: "U"},
-      {re: /[\xF9-\xFC]/g, ch: "u"},
-      {re: /[\xC7-\xE7]/g, ch: "c"},
-      {re: /[\xD1]/g, ch: "N"},
-      {re: /[\xF1]/g, ch: "n"}
-    ];
-    $.each(rExps, function () {
-      text = text.replace(this.re, this.ch);
+  var generateA = function (text, classes, inline, tokens) {
+    return '<a tabindex="0"' +
+        (typeof classes !== 'undefined' ? ' class="' + classes + '"' : '') +
+        (typeof inline !== 'undefined' ? ' style="' + inline + '"' : '') +
+        ' data-normalized-text="' + normalizeToBase(htmlEscape(text)) + '"' +
+        (typeof tokens !== 'undefined' || tokens !== null ? ' data-tokens="' + tokens + '"' : '') +
+        '>' + text +
+        '<span class="' + that.options.iconBase + ' ' + that.options.tickIcon + ' check-mark"></span>' +
+        '</a>';
+  };
+
+  this.$element.find('option').each(function (index) {
+    var $this = $(this);
+
+    // Get the class and text for the option
+    var optionClass = $this.attr('class') || '',
+        inline = $this.attr('style'),
+        text = $this.data('content') ? $this.data('content') : $this.html(),
+        tokens = $this.data('tokens') ? $this.data('tokens') : null,
+        subtext = typeof $this.data('subtext') !== 'undefined' ? '<small class="text-muted">' + $this.data('subtext') + '</small>' : '',
+        icon = typeof $this.data('icon') !== 'undefined' ? '<span class="' + that.options.iconBase + ' ' + $this.data('icon') + '"></span> ' : '',
+        isDisabled = $this.is(':disabled') || $this.parent().is(':disabled');
+    if (icon !== '' && isDisabled) {
+      icon = '<span>' + icon + '</span>';
+    }
+
+    if (!$this.data('content')) {
+      // Prepend any icon and append any subtext to the main text.
+      text = icon + '<span class="text">' + text + subtext + '</span>';
+    }
+
+    if (that.options.hideDisabled && isDisabled) {
+      return;
+    }
+
+    if ($this.parent().is('optgroup') && $this.data('divider') !== true) {
+      if ($this.index() === 0) { // Is it the first option of the optgroup?
+        optID += 1;
+
+        // Get the opt group label
+        var label = $this.parent().attr('label');
+        var labelSubtext = typeof $this.parent().data('subtext') !== 'undefined' ? '<small class="text-muted">' + $this.parent().data('subtext') + '</small>' : '';
+        var labelIcon = $this.parent().data('icon') ? '<span class="' + that.options.iconBase + ' ' + $this.parent().data('icon') + '"></span> ' : '';
+        label = labelIcon + '<span class="text">' + label + labelSubtext + '</span>';
+
+        if (index !== 0 && _li.length > 0) { // Is it NOT the first option of the select && are there elements in the dropdown?
+          _li.push(generateLI('', null, 'divider'));
+        }
+
+        _li.push(generateLI(label, null, 'dropdown-header', optID));
+      }
+
+      _li.push(generateLI(generateA(text, 'opt ' + optionClass, inline, tokens), index, '', optID));
+    } else if ($this.data('divider') === true) {
+      _li.push(generateLI('', index, 'divider'));
+    } else if ($this.data('hidden') === true) {
+      _li.push(generateLI(generateA(text, optionClass, inline, tokens), index, 'hidden is-hidden'));
+    } else {
+      _li.push(generateLI(generateA(text, optionClass, inline, tokens), index));
+    }
+  });
+
+  //If we are not multiple, we don't have a selected item, and we don't have a title, select the first element so something is set in the button
+  if (!this.multiple && this.$element.find('option:selected').length === 0 && !this.options.title) {
+    this.$element.find('option').eq(0).prop('selected', true).attr('selected', 'selected');
+  }
+
+  return $(_li.join(''));
+},
+
+findLis: function () {
+  if (this.$lis == null) this.$lis = this.$menu.find('li');
+  return this.$lis;
+},
+
+/**
+ * @param [updateLi] defaults to true
+ */
+render: function (updateLi) {
+  var that = this;
+
+  //Update the LI to match the SELECT
+  if (updateLi !== false) {
+    this.$element.find('option').each(function (index) {
+      that.setDisabled(index, $(this).is(':disabled') || $(this).parent().is(':disabled'));
+      that.setSelected(index, $(this).is(':selected'));
     });
-    return text;
   }
 
+  this.tabIndex();
+  var notDisabled = this.options.hideDisabled ? ':not([disabled])' : '';
+  var selectedItems = this.$element.find('option:selected' + notDisabled).map(function () {
+    var $this = $(this);
+    var icon = $this.data('icon') && that.options.showIcon ? '<i class="' + that.options.iconBase + ' ' + $this.data('icon') + '"></i> ' : '';
+    var subtext;
+    if (that.options.showSubtext && $this.attr('data-subtext') && !that.multiple) {
+      subtext = ' <small class="text-muted">' + $this.data('subtext') + '</small>';
+    } else {
+      subtext = '';
+    }
+    if (typeof $this.attr('title') !== 'undefined') {
+      return $this.attr('title');
+    } else if ($this.data('content') && that.options.showContent) {
+      return $this.data('content');
+    } else {
+      return icon + $this.html() + subtext;
+    }
+  }).toArray();
 
-  function htmlEscape(html) {
-    var escapeMap = {
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-      "'": '&#x27;',
-      '`': '&#x60;'
-    };
-    var source = '(?:' + Object.keys(escapeMap).join('|') + ')',
-        testRegexp = new RegExp(source),
-        replaceRegexp = new RegExp(source, 'g'),
-        string = html == null ? '' : '' + html;
-    return testRegexp.test(string) ? string.replace(replaceRegexp, function (match) {
-      return escapeMap[match];
-    }) : string;
+  //Fixes issue in IE10 occurring when no default option is selected and at least one option is disabled
+  //Convert all the values into a comma delimited string
+  var title = !this.multiple ? selectedItems[0] : selectedItems.join(this.options.multipleSeparator);
+
+  //If this is multi select, and the selectText type is count, the show 1 of 2 selected etc..
+  if (this.multiple && this.options.selectedTextFormat.indexOf('count') > -1) {
+    var max = this.options.selectedTextFormat.split('>');
+    if ((max.length > 1 && selectedItems.length > max[1]) || (max.length == 1 && selectedItems.length >= 2)) {
+      notDisabled = this.options.hideDisabled ? ', [disabled]' : '';
+      var totalCount = this.$element.find('option').not('[data-divider="true"], [data-hidden="true"]' + notDisabled).length,
+          tr8nText = (typeof this.options.countSelectedText === 'function') ? this.options.countSelectedText(selectedItems.length, totalCount) : this.options.countSelectedText;
+      title = tr8nText.replace('{0}', selectedItems.length.toString()).replace('{1}', totalCount.toString());
+    }
   }
 
-  var Selectpicker = function (element, options, e) {
-    if (e) {
-      e.stopPropagation();
-      e.preventDefault();
-    }
+  if (this.options.title == undefined) {
+    this.options.title = this.$element.attr('title');
+  }
 
-    this.$element = $(element);
-    this.$newElement = null;
-    this.$button = null;
-    this.$menu = null;
-    this.$lis = null;
-    this.options = options;
+  if (this.options.selectedTextFormat == 'static') {
+    title = this.options.title;
+  }
 
-    // If we have no title yet, try to pull it from the html title attribute (jQuery doesnt' pick it up as it's not a
-    // data-attribute)
-    if (this.options.title === null) {
-      this.options.title = this.$element.attr('title');
-    }
+  //If we dont have a title, then use the default, or if nothing is set at all, use the not selected text
+  if (!title) {
+    title = typeof this.options.title !== 'undefined' ? this.options.title : this.options.noneSelectedText;
+  }
 
-    //Expose public methods
-    this.val = Selectpicker.prototype.val;
-    this.render = Selectpicker.prototype.render;
-    this.refresh = Selectpicker.prototype.refresh;
-    this.setStyle = Selectpicker.prototype.setStyle;
-    this.selectAll = Selectpicker.prototype.selectAll;
-    this.deselectAll = Selectpicker.prototype.deselectAll;
-    this.destroy = Selectpicker.prototype.remove;
-    this.remove = Selectpicker.prototype.remove;
-    this.show = Selectpicker.prototype.show;
-    this.hide = Selectpicker.prototype.hide;
+  //strip all html-tags and trim the result
+  this.$button.attr('title', $.trim(title.replace(/<[^>]*>?/g, '')));
+  this.$newElement.find('.filter-option').html(title);
+},
 
-    this.init();
-  };
+/**
+ * @param [style]
+ * @param [status]
+ */
+setStyle: function (style, status) {
+  if (this.$element.attr('class')) {
+    this.$newElement.addClass(this.$element.attr('class').replace(/selectpicker|mobile-device|validate\[.*\]/gi, ''));
+  }
 
-  Selectpicker.VERSION = '1.6.3';
+  var buttonClass = style ? style : this.options.style;
 
-  // part of this is duplicated in i18n/defaults-en_US.js. Make sure to update both.
-  Selectpicker.DEFAULTS = {
-    noneSelectedText: 'Nothing selected',
-    noneResultsText: 'No results matched {0}',
-    countSelectedText: function (numSelected, numTotal) {
-      return (numSelected == 1) ? "{0} item selected" : "{0} items selected";
-    },
-    maxOptionsText: function (numAll, numGroup) {
-      return [
-        (numAll == 1) ? 'Limit reached ({n} item max)' : 'Limit reached ({n} items max)',
-        (numGroup == 1) ? 'Group limit reached ({n} item max)' : 'Group limit reached ({n} items max)'
-      ];
-    },
-    selectAllText: 'Select All',
-    deselectAllText: 'Deselect All',
-    doneButton: false,
-    doneButtonText: 'Close',
-    multipleSeparator: ', ',
-    style: 'btn-default',
-    size: 'auto',
-    title: null,
-    selectedTextFormat: 'values',
-    width: false,
-    container: false,
-    hideDisabled: false,
-    showSubtext: false,
-    showIcon: true,
-    showContent: true,
-    dropupAuto: true,
-    header: false,
-    liveSearch: false,
-    liveSearchPlaceholder: null,
-    liveSearchNormalize: false,
-    liveSearchStyle: 'contains',
-    actionsBox: false,
-    iconBase: 'glyphicon',
-    tickIcon: 'glyphicon-ok',
-    maxOptions: false,
-    mobile: false,
-    selectOnTab: false,
-    dropdownAlignRight: false
-  };
+  if (status == 'add') {
+    this.$button.addClass(buttonClass);
+  } else if (status == 'remove') {
+    this.$button.removeClass(buttonClass);
+  } else {
+    this.$button.removeClass(this.options.style);
+    this.$button.addClass(buttonClass);
+  }
+},
 
-  Selectpicker.prototype = {
+liHeight: function () {
+  if (this.options.size === false) return;
 
-    constructor: Selectpicker,
+  var $selectClone = this.$menu.parent().clone().children('.dropdown-toggle').prop('autofocus', false).end().appendTo('body'),
+      $menuClone = $selectClone.addClass('open').children('.dropdown-menu'),
+      liHeight = $menuClone.find('li').not('.divider').not('.dropdown-header').filter(':visible').children('a').outerHeight(),
+      headerHeight = this.options.header ? $menuClone.find('.popover-title').outerHeight() : 0,
+      searchHeight = this.options.liveSearch ? $menuClone.find('.bs-searchbox').outerHeight() : 0,
+      actionsHeight = this.options.actionsBox ? $menuClone.find('.bs-actionsbox').outerHeight() : 0,
+      doneButtonHeight = this.multiple ? $menuClone.find('.bs-donebutton').outerHeight() : 0;
 
-    init: function () {
-      var that = this,
-          id = this.$element.attr('id');
+  $selectClone.remove();
 
-      this.$element.hide();
-      this.multiple = this.$element.prop('multiple');
-      this.autofocus = this.$element.prop('autofocus');
-      this.$newElement = this.createView();
-      this.$element.after(this.$newElement);
-      this.$menu = this.$newElement.children('.dropdown-menu');
-      this.$button = this.$newElement.children('button');
-      this.$searchbox = this.$newElement.find('input');
+  this.$newElement
+      .data('liHeight', liHeight)
+      .data('headerHeight', headerHeight)
+      .data('searchHeight', searchHeight)
+      .data('actionsHeight', actionsHeight)
+      .data('doneButtonHeight', doneButtonHeight);
+},
 
-      if (this.options.dropdownAlignRight)
-        this.$menu.addClass('dropdown-menu-right');
-
-      if (typeof id !== 'undefined') {
-        this.$button.attr('data-id', id);
-        $('label[for="' + id + '"]').click(function (e) {
-          e.preventDefault();
-          that.$button.focus();
-        });
-      }
-
-      this.checkDisabled();
-      this.clickListener();
-      if (this.options.liveSearch) this.liveSearchListener();
-      this.render();
-      this.liHeight();
-      this.setStyle();
-      this.setWidth();
-      if (this.options.container) this.selectPosition();
-      this.$menu.data('this', this);
-      this.$newElement.data('this', this);
-      if (this.options.mobile) this.mobile();
-    },
-
-    createDropdown: function () {
-      // Options
-      // If we are multiple, then add the show-tick class by default
-      var multiple = this.multiple ? ' show-tick' : '',
-          inputGroup = this.$element.parent().hasClass('input-group') ? ' input-group-btn' : '',
-          autofocus = this.autofocus ? ' autofocus' : '';
-      // Elements
-      var header = this.options.header ? '<div class="popover-title"><button type="button" class="close" aria-hidden="true">&times;</button>' + this.options.header + '</div>' : '';
-      var searchbox = this.options.liveSearch ?
-      '<div class="bs-searchbox">' +
-      '<input type="text" class="form-control" autocomplete="off"' +
-      (null === this.options.liveSearchPlaceholder ? '' : ' placeholder="' + htmlEscape(this.options.liveSearchPlaceholder) + '"') + '>' +
-      '</div>'
-          : '';
-      var actionsbox = this.multiple && this.options.actionsBox ?
-      '<div class="bs-actionsbox">' +
-      '<div class="btn-group btn-group-sm btn-block">' +
-      '<button class="actions-btn bs-select-all btn btn-default">' +
-      this.options.selectAllText +
-      '</button>' +
-      '<button class="actions-btn bs-deselect-all btn btn-default">' +
-      this.options.deselectAllText +
-      '</button>' +
-      '</div>' +
-      '</div>'
-          : '';
-      var donebutton = this.multiple && this.options.doneButton ?
-      '<div class="bs-donebutton">' +
-      '<div class="btn-group btn-block">' +
-      '<button class="btn btn-sm btn-default">' +
-      this.options.doneButtonText +
-      '</button>' +
-      '</div>' +
-      '</div>'
-          : '';
-      var drop =
-          '<div class="btn-group bootstrap-select' + multiple + inputGroup + '">' +
-          '<button type="button" class="btn dropdown-toggle form-control selectpicker" data-toggle="dropdown"' + autofocus + '>' +
-          '<span class="filter-option pull-left"></span>&nbsp;' +
-          '<span class="caret"></span>' +
-          '</button>' +
-          '<div class="dropdown-menu open">' +
-          header +
-          searchbox +
-          actionsbox +
-          '<ul class="dropdown-menu inner selectpicker" role="menu">' +
-          '</ul>' +
-          donebutton +
-          '</div>' +
-          '</div>';
-
-      return $(drop);
-    },
-
-    createView: function () {
-      var $drop = this.createDropdown();
-      var $li = this.createLi();
-      $drop.find('ul').append($li);
-      return $drop;
-    },
-
-    reloadLi: function () {
-      //Remove all children.
-      this.destroyLi();
-      //Re build
-      var $li = this.createLi();
-      this.$menu.find('ul').append($li);
-    },
-
-    destroyLi: function () {
-      this.$menu.find('li').remove();
-    },
-
-    createLi: function () {
-      var that = this,
-          _li = [],
-          optID = 0;
-
-      // Helper functions
-      /**
-       * @param content
-       * @param [index]
-       * @param [classes]
-       * @param [optgroup]
-       * @returns {string}
-       */
-      var generateLI = function (content, index, classes, optgroup) {
-        return '<li' +
-            ((typeof classes !== 'undefined' & '' !== classes) ? ' class="' + classes + '"' : '') +
-            ((typeof index !== 'undefined' & null !== index) ? ' data-original-index="' + index + '"' : '') +
-            ((typeof optgroup !== 'undefined' & null !== optgroup) ? 'data-optgroup="' + optgroup + '"' : '') +
-            '>' + content + '</li>';
+setSize: function () {
+  this.findLis();
+  var that = this,
+      menu = this.$menu,
+      menuInner = menu.find('.inner'),
+      selectHeight = this.$newElement.outerHeight(),
+      liHeight = this.$newElement.data('liHeight'),
+      headerHeight = this.$newElement.data('headerHeight'),
+      searchHeight = this.$newElement.data('searchHeight'),
+      actionsHeight = this.$newElement.data('actionsHeight'),
+      doneButtonHeight = this.$newElement.data('doneButtonHeight'),
+      divHeight = this.$lis.filter('.divider').outerHeight(true),
+      menuPadding = parseInt(menu.css('padding-top')) +
+          parseInt(menu.css('padding-bottom')) +
+          parseInt(menu.css('border-top-width')) +
+          parseInt(menu.css('border-bottom-width')),
+      notDisabled = this.options.hideDisabled ? ', .disabled' : '',
+      $window = $(window),
+      menuExtras = menuPadding + parseInt(menu.css('margin-top')) + parseInt(menu.css('margin-bottom')) + 2,
+      menuHeight,
+      selectOffsetTop,
+      selectOffsetBot,
+      posVert = function () {
+        // JQuery defines a scrollTop function, but in pure JS it's a property
+        //noinspection JSValidateTypes
+        selectOffsetTop = that.$newElement.offset().top - $window.scrollTop();
+        selectOffsetBot = $window.height() - selectOffsetTop - selectHeight;
       };
+  posVert();
+  if (this.options.header) menu.css('padding-top', 0);
 
-      /**
-       * @param text
-       * @param [classes]
-       * @param [inline]
-       * @param [tokens]
-       * @returns {string}
-       */
-      var generateA = function (text, classes, inline, tokens) {
-        return '<a tabindex="0"' +
-            (typeof classes !== 'undefined' ? ' class="' + classes + '"' : '') +
-            (typeof inline !== 'undefined' ? ' style="' + inline + '"' : '') +
-            ' data-normalized-text="' + normalizeToBase(htmlEscape(text)) + '"' +
-            (typeof tokens !== 'undefined' || tokens !== null ? ' data-tokens="' + tokens + '"' : '') +
-            '>' + text +
-            '<span class="' + that.options.iconBase + ' ' + that.options.tickIcon + ' check-mark"></span>' +
-            '</a>';
-      };
+  if (this.options.size == 'auto') {
+    var getSize = function () {
+      var minHeight,
+          lisVis = that.$lis.not('.hidden');
 
-      this.$element.find('option').each(function (index) {
-        var $this = $(this);
-
-        // Get the class and text for the option
-        var optionClass = $this.attr('class') || '',
-            inline = $this.attr('style'),
-            text = $this.data('content') ? $this.data('content') : $this.html(),
-            tokens = $this.data('tokens') ? $this.data('tokens') : null,
-            subtext = typeof $this.data('subtext') !== 'undefined' ? '<small class="text-muted">' + $this.data('subtext') + '</small>' : '',
-            icon = typeof $this.data('icon') !== 'undefined' ? '<span class="' + that.options.iconBase + ' ' + $this.data('icon') + '"></span> ' : '',
-            isDisabled = $this.is(':disabled') || $this.parent().is(':disabled');
-        if (icon !== '' && isDisabled) {
-          icon = '<span>' + icon + '</span>';
-        }
-
-        if (!$this.data('content')) {
-          // Prepend any icon and append any subtext to the main text.
-          text = icon + '<span class="text">' + text + subtext + '</span>';
-        }
-
-        if (that.options.hideDisabled && isDisabled) {
-          return;
-        }
-
-        if ($this.parent().is('optgroup') && $this.data('divider') !== true) {
-          if ($this.index() === 0) { // Is it the first option of the optgroup?
-            optID += 1;
-
-            // Get the opt group label
-            var label = $this.parent().attr('label');
-            var labelSubtext = typeof $this.parent().data('subtext') !== 'undefined' ? '<small class="text-muted">' + $this.parent().data('subtext') + '</small>' : '';
-            var labelIcon = $this.parent().data('icon') ? '<span class="' + that.options.iconBase + ' ' + $this.parent().data('icon') + '"></span> ' : '';
-            label = labelIcon + '<span class="text">' + label + labelSubtext + '</span>';
-
-            if (index !== 0 && _li.length > 0) { // Is it NOT the first option of the select && are there elements in the dropdown?
-              _li.push(generateLI('', null, 'divider'));
-            }
-
-            _li.push(generateLI(label, null, 'dropdown-header', optID));
-          }
-
-          _li.push(generateLI(generateA(text, 'opt ' + optionClass, inline, tokens), index, '', optID));
-        } else if ($this.data('divider') === true) {
-          _li.push(generateLI('', index, 'divider'));
-        } else if ($this.data('hidden') === true) {
-          _li.push(generateLI(generateA(text, optionClass, inline, tokens), index, 'hidden is-hidden'));
-        } else {
-          _li.push(generateLI(generateA(text, optionClass, inline, tokens), index));
-        }
-      });
-
-      //If we are not multiple, we don't have a selected item, and we don't have a title, select the first element so something is set in the button
-      if (!this.multiple && this.$element.find('option:selected').length === 0 && !this.options.title) {
-        this.$element.find('option').eq(0).prop('selected', true).attr('selected', 'selected');
-      }
-
-      return $(_li.join(''));
-    },
-
-    findLis: function () {
-      if (this.$lis == null) this.$lis = this.$menu.find('li');
-      return this.$lis;
-    },
-
-    /**
-     * @param [updateLi] defaults to true
-     */
-    render: function (updateLi) {
-      var that = this;
-
-      //Update the LI to match the SELECT
-      if (updateLi !== false) {
-        this.$element.find('option').each(function (index) {
-          that.setDisabled(index, $(this).is(':disabled') || $(this).parent().is(':disabled'));
-          that.setSelected(index, $(this).is(':selected'));
-        });
-      }
-
-      this.tabIndex();
-      var notDisabled = this.options.hideDisabled ? ':not([disabled])' : '';
-      var selectedItems = this.$element.find('option:selected' + notDisabled).map(function () {
-        var $this = $(this);
-        var icon = $this.data('icon') && that.options.showIcon ? '<i class="' + that.options.iconBase + ' ' + $this.data('icon') + '"></i> ' : '';
-        var subtext;
-        if (that.options.showSubtext && $this.attr('data-subtext') && !that.multiple) {
-          subtext = ' <small class="text-muted">' + $this.data('subtext') + '</small>';
-        } else {
-          subtext = '';
-        }
-        if (typeof $this.attr('title') !== 'undefined') {
-          return $this.attr('title');
-        } else if ($this.data('content') && that.options.showContent) {
-          return $this.data('content');
-        } else {
-          return icon + $this.html() + subtext;
-        }
-      }).toArray();
-
-      //Fixes issue in IE10 occurring when no default option is selected and at least one option is disabled
-      //Convert all the values into a comma delimited string
-      var title = !this.multiple ? selectedItems[0] : selectedItems.join(this.options.multipleSeparator);
-
-      //If this is multi select, and the selectText type is count, the show 1 of 2 selected etc..
-      if (this.multiple && this.options.selectedTextFormat.indexOf('count') > -1) {
-        var max = this.options.selectedTextFormat.split('>');
-        if ((max.length > 1 && selectedItems.length > max[1]) || (max.length == 1 && selectedItems.length >= 2)) {
-          notDisabled = this.options.hideDisabled ? ', [disabled]' : '';
-          var totalCount = this.$element.find('option').not('[data-divider="true"], [data-hidden="true"]' + notDisabled).length,
-              tr8nText = (typeof this.options.countSelectedText === 'function') ? this.options.countSelectedText(selectedItems.length, totalCount) : this.options.countSelectedText;
-          title = tr8nText.replace('{0}', selectedItems.length.toString()).replace('{1}', totalCount.toString());
-        }
-      }
-
-      if (this.options.title == undefined) {
-        this.options.title = this.$element.attr('title');
-      }
-
-      if (this.options.selectedTextFormat == 'static') {
-        title = this.options.title;
-      }
-
-      //If we dont have a title, then use the default, or if nothing is set at all, use the not selected text
-      if (!title) {
-        title = typeof this.options.title !== 'undefined' ? this.options.title : this.options.noneSelectedText;
-      }
-
-      //strip all html-tags and trim the result
-      this.$button.attr('title', $.trim(title.replace(/<[^>]*>?/g, '')));
-      this.$newElement.find('.filter-option').html(title);
-    },
-
-    /**
-     * @param [style]
-     * @param [status]
-     */
-    setStyle: function (style, status) {
-      if (this.$element.attr('class')) {
-        this.$newElement.addClass(this.$element.attr('class').replace(/selectpicker|mobile-device|validate\[.*\]/gi, ''));
-      }
-
-      var buttonClass = style ? style : this.options.style;
-
-      if (status == 'add') {
-        this.$button.addClass(buttonClass);
-      } else if (status == 'remove') {
-        this.$button.removeClass(buttonClass);
-      } else {
-        this.$button.removeClass(this.options.style);
-        this.$button.addClass(buttonClass);
-      }
-    },
-
-    liHeight: function () {
-      if (this.options.size === false) return;
-
-      var $selectClone = this.$menu.parent().clone().children('.dropdown-toggle').prop('autofocus', false).end().appendTo('body'),
-          $menuClone = $selectClone.addClass('open').children('.dropdown-menu'),
-          liHeight = $menuClone.find('li').not('.divider').not('.dropdown-header').filter(':visible').children('a').outerHeight(),
-          headerHeight = this.options.header ? $menuClone.find('.popover-title').outerHeight() : 0,
-          searchHeight = this.options.liveSearch ? $menuClone.find('.bs-searchbox').outerHeight() : 0,
-          actionsHeight = this.options.actionsBox ? $menuClone.find('.bs-actionsbox').outerHeight() : 0,
-          doneButtonHeight = this.multiple ? $menuClone.find('.bs-donebutton').outerHeight() : 0;
-
-      $selectClone.remove();
-
-      this.$newElement
-          .data('liHeight', liHeight)
-          .data('headerHeight', headerHeight)
-          .data('searchHeight', searchHeight)
-          .data('actionsHeight', actionsHeight)
-          .data('doneButtonHeight', doneButtonHeight);
-    },
-
-    setSize: function () {
-      this.findLis();
-      var that = this,
-          menu = this.$menu,
-          menuInner = menu.find('.inner'),
-          selectHeight = this.$newElement.outerHeight(),
-          liHeight = this.$newElement.data('liHeight'),
-          headerHeight = this.$newElement.data('headerHeight'),
-          searchHeight = this.$newElement.data('searchHeight'),
-          actionsHeight = this.$newElement.data('actionsHeight'),
-          doneButtonHeight = this.$newElement.data('doneButtonHeight'),
-          divHeight = this.$lis.filter('.divider').outerHeight(true),
-          menuPadding = parseInt(menu.css('padding-top')) +
-              parseInt(menu.css('padding-bottom')) +
-              parseInt(menu.css('border-top-width')) +
-              parseInt(menu.css('border-bottom-width')),
-          notDisabled = this.options.hideDisabled ? ', .disabled' : '',
-          $window = $(window),
-          menuExtras = menuPadding + parseInt(menu.css('margin-top')) + parseInt(menu.css('margin-bottom')) + 2,
-          menuHeight,
-          selectOffsetTop,
-          selectOffsetBot,
-          posVert = function () {
-            // JQuery defines a scrollTop function, but in pure JS it's a property
-            //noinspection JSValidateTypes
-            selectOffsetTop = that.$newElement.offset().top - $window.scrollTop();
-            selectOffsetBot = $window.height() - selectOffsetTop - selectHeight;
-          };
       posVert();
-      if (this.options.header) menu.css('padding-top', 0);
+      menuHeight = selectOffsetBot - menuExtras;
 
-      if (this.options.size == 'auto') {
-        var getSize = function () {
-          var minHeight,
-              lisVis = that.$lis.not('.hidden');
+      if (that.options.dropupAuto) {
+        that.$newElement.toggleClass('dropup', selectOffsetTop > selectOffsetBot && (menuHeight - menuExtras) < menu.height());
+      }
+      if (that.$newElement.hasClass('dropup')) {
+        menuHeight = selectOffsetTop - menuExtras;
+      }
 
-          posVert();
-          menuHeight = selectOffsetBot - menuExtras;
+      if ((lisVis.length + lisVis.filter('.dropdown-header').length) > 3) {
+        minHeight = liHeight * 3 + menuExtras - 2;
+      } else {
+        minHeight = 0;
+      }
 
-          if (that.options.dropupAuto) {
-            that.$newElement.toggleClass('dropup', selectOffsetTop > selectOffsetBot && (menuHeight - menuExtras) < menu.height());
-          }
-          if (that.$newElement.hasClass('dropup')) {
-            menuHeight = selectOffsetTop - menuExtras;
-          }
+      menu.css({
+        'max-height': menuHeight + 'px',
+        'overflow': 'hidden',
+        'min-height': minHeight + headerHeight + searchHeight + actionsHeight + doneButtonHeight + 'px'
+      });
+      menuInner.css({
+        'max-height': menuHeight - headerHeight - searchHeight - actionsHeight - doneButtonHeight - menuPadding + 'px',
+        'overflow-y': 'auto',
+        'min-height': Math.max(minHeight - menuPadding, 0) + 'px'
+      });
+    };
+    getSize();
+    this.$searchbox.off('input.getSize propertychange.getSize').on('input.getSize propertychange.getSize', getSize);
+    $window.off('resize.getSize').on('resize.getSize', getSize);
+    $window.off('scroll.getSize').on('scroll.getSize', getSize);
+  } else if (this.options.size && this.options.size != 'auto' && menu.find('li' + notDisabled).length > this.options.size) {
+    var optIndex = this.$lis.not('.divider' + notDisabled).children().slice(0, this.options.size).last().parent().index();
+    var divLength = this.$lis.slice(0, optIndex + 1).filter('.divider').length;
+    menuHeight = liHeight * this.options.size + divLength * divHeight + menuPadding;
+    if (that.options.dropupAuto) {
+      //noinspection JSUnusedAssignment
+      this.$newElement.toggleClass('dropup', selectOffsetTop > selectOffsetBot && menuHeight < menu.height());
+    }
+    menu.css({
+      'max-height': menuHeight + headerHeight + searchHeight + actionsHeight + doneButtonHeight + 'px',
+      'overflow': 'hidden'
+    });
+    menuInner.css({'max-height': menuHeight - menuPadding + 'px', 'overflow-y': 'auto'});
+  }
+},
 
-          if ((lisVis.length + lisVis.filter('.dropdown-header').length) > 3) {
-            minHeight = liHeight * 3 + menuExtras - 2;
-          } else {
-            minHeight = 0;
-          }
+setWidth: function () {
+  if (this.options.width == 'auto') {
+    this.$menu.css('min-width', '0');
 
-          menu.css({
-            'max-height': menuHeight + 'px',
-            'overflow': 'hidden',
-            'min-height': minHeight + headerHeight + searchHeight + actionsHeight + doneButtonHeight + 'px'
-          });
-          menuInner.css({
-            'max-height': menuHeight - headerHeight - searchHeight - actionsHeight - doneButtonHeight - menuPadding + 'px',
-            'overflow-y': 'auto',
-            'min-height': Math.max(minHeight - menuPadding, 0) + 'px'
-          });
-        };
-        getSize();
-        this.$searchbox.off('input.getSize propertychange.getSize').on('input.getSize propertychange.getSize', getSize);
-        $window.off('resize.getSize').on('resize.getSize', getSize);
-        $window.off('scroll.getSize').on('scroll.getSize', getSize);
-      } else if (this.options.size && this.options.size != 'auto' && menu.find('li' + notDisabled).length > this.options.size) {
-        var optIndex = this.$lis.not('.divider' + notDisabled).children().slice(0, this.options.size).last().parent().index();
-        var divLength = this.$lis.slice(0, optIndex + 1).filter('.divider').length;
-        menuHeight = liHeight * this.options.size + divLength * divHeight + menuPadding;
-        if (that.options.dropupAuto) {
-          //noinspection JSUnusedAssignment
-          this.$newElement.toggleClass('dropup', selectOffsetTop > selectOffsetBot && menuHeight < menu.height());
-        }
-        menu.css({
-          'max-height': menuHeight + headerHeight + searchHeight + actionsHeight + doneButtonHeight + 'px',
-          'overflow': 'hidden'
+    // Get correct width if element hidden
+    var selectClone = this.$newElement.clone().appendTo('body');
+    var ulWidth = selectClone.children('.dropdown-menu').css('width');
+    var btnWidth = selectClone.css('width', 'auto').children('button').css('width');
+    selectClone.remove();
+
+    // Set width to whatever's larger, button title or longest option
+    this.$newElement.css('width', Math.max(parseInt(ulWidth), parseInt(btnWidth)) + 'px');
+  } else if (this.options.width == 'fit') {
+    // Remove inline min-width so width can be changed from 'auto'
+    this.$menu.css('min-width', '');
+    this.$newElement.css('width', '').addClass('fit-width');
+  } else if (this.options.width) {
+    // Remove inline min-width so width can be changed from 'auto'
+    this.$menu.css('min-width', '');
+    this.$newElement.css('width', this.options.width);
+  } else {
+    // Remove inline min-width/width so width can be changed
+    this.$menu.css('min-width', '');
+    this.$newElement.css('width', '');
+  }
+  // Remove fit-width class if width is changed programmatically
+  if (this.$newElement.hasClass('fit-width') && this.options.width !== 'fit') {
+    this.$newElement.removeClass('fit-width');
+  }
+},
+
+selectPosition: function () {
+  var that = this,
+      drop = '<div />',
+      $drop = $(drop),
+      pos,
+      actualHeight,
+      getPlacement = function ($element) {
+        $drop.addClass($element.attr('class').replace(/form-control/gi, '')).toggleClass('dropup', $element.hasClass('dropup'));
+        pos = $element.offset();
+        actualHeight = $element.hasClass('dropup') ? 0 : $element[0].offsetHeight;
+        $drop.css({
+          'top': pos.top + actualHeight,
+          'left': pos.left,
+          'width': $element[0].offsetWidth,
+          'position': 'absolute'
         });
-        menuInner.css({'max-height': menuHeight - menuPadding + 'px', 'overflow-y': 'auto'});
-      }
-    },
+      };
+  this.$newElement.on('click', function () {
+    if (that.isDisabled()) {
+      return;
+    }
+    getPlacement($(this));
+    $drop.appendTo(that.options.container);
+    $drop.toggleClass('open', !$(this).hasClass('open'));
+    $drop.append(that.$menu);
+  });
+  $(window).resize(function () {
+    getPlacement(that.$newElement);
+  });
+  $(window).on('scroll', function () {
+    getPlacement(that.$newElement);
+  });
+  $('html').on('click', function (e) {
+    if ($(e.target).closest(that.$newElement).length < 1) {
+      $drop.removeClass('open');
+    }
+  });
+},
 
-    setWidth: function () {
-      if (this.options.width == 'auto') {
-        this.$menu.css('min-width', '0');
+setSelected: function (index, selected) {
+  this.findLis();
+  this.$lis.filter('[data-original-index="' + index + '"]').toggleClass('selected', selected);
+},
 
-        // Get correct width if element hidden
-        var selectClone = this.$newElement.clone().appendTo('body');
-        var ulWidth = selectClone.children('.dropdown-menu').css('width');
-        var btnWidth = selectClone.css('width', 'auto').children('button').css('width');
-        selectClone.remove();
+setDisabled: function (index, disabled) {
+  this.findLis();
+  if (disabled) {
+    this.$lis.filter('[data-original-index="' + index + '"]').addClass('disabled').find('a').attr('href', '#').attr('tabindex', -1);
+  } else {
+    this.$lis.filter('[data-original-index="' + index + '"]').removeClass('disabled').find('a').removeAttr('href').attr('tabindex', 0);
+  }
+},
 
-        // Set width to whatever's larger, button title or longest option
-        this.$newElement.css('width', Math.max(parseInt(ulWidth), parseInt(btnWidth)) + 'px');
-      } else if (this.options.width == 'fit') {
-        // Remove inline min-width so width can be changed from 'auto'
-        this.$menu.css('min-width', '');
-        this.$newElement.css('width', '').addClass('fit-width');
-      } else if (this.options.width) {
-        // Remove inline min-width so width can be changed from 'auto'
-        this.$menu.css('min-width', '');
-        this.$newElement.css('width', this.options.width);
-      } else {
-        // Remove inline min-width/width so width can be changed
-        this.$menu.css('min-width', '');
-        this.$newElement.css('width', '');
-      }
-      // Remove fit-width class if width is changed programmatically
-      if (this.$newElement.hasClass('fit-width') && this.options.width !== 'fit') {
-        this.$newElement.removeClass('fit-width');
-      }
-    },
+isDisabled: function () {
+  return this.$element.is(':disabled');
+},
 
-    selectPosition: function () {
-      var that = this,
-          drop = '<div />',
-          $drop = $(drop),
-          pos,
-          actualHeight,
-          getPlacement = function ($element) {
-            $drop.addClass($element.attr('class').replace(/form-control/gi, '')).toggleClass('dropup', $element.hasClass('dropup'));
-            pos = $element.offset();
-            actualHeight = $element.hasClass('dropup') ? 0 : $element[0].offsetHeight;
-            $drop.css({
-              'top': pos.top + actualHeight,
-              'left': pos.left,
-              'width': $element[0].offsetWidth,
-              'position': 'absolute'
-            });
-          };
-      this.$newElement.on('click', function () {
-        if (that.isDisabled()) {
-          return;
-        }
-        getPlacement($(this));
-        $drop.appendTo(that.options.container);
-        $drop.toggleClass('open', !$(this).hasClass('open'));
-        $drop.append(that.$menu);
-      });
-      $(window).resize(function () {
-        getPlacement(that.$newElement);
-      });
-      $(window).on('scroll', function () {
-        getPlacement(that.$newElement);
-      });
-      $('html').on('click', function (e) {
-        if ($(e.target).closest(that.$newElement).length < 1) {
-          $drop.removeClass('open');
-        }
-      });
-    },
+checkDisabled: function () {
+  var that = this;
 
-    setSelected: function (index, selected) {
-      this.findLis();
-      this.$lis.filter('[data-original-index="' + index + '"]').toggleClass('selected', selected);
-    },
+  if (this.isDisabled()) {
+    this.$button.addClass('disabled').attr('tabindex', -1);
+  } else {
+    if (this.$button.hasClass('disabled')) {
+      this.$button.removeClass('disabled');
+    }
 
-    setDisabled: function (index, disabled) {
-      this.findLis();
-      if (disabled) {
-        this.$lis.filter('[data-original-index="' + index + '"]').addClass('disabled').find('a').attr('href', '#').attr('tabindex', -1);
-      } else {
-        this.$lis.filter('[data-original-index="' + index + '"]').removeClass('disabled').find('a').removeAttr('href').attr('tabindex', 0);
-      }
-    },
+    if (this.$button.attr('tabindex') == -1) {
+      if (!this.$element.data('tabindex')) this.$button.removeAttr('tabindex');
+    }
+  }
 
-    isDisabled: function () {
-      return this.$element.is(':disabled');
-    },
+  this.$button.click(function () {
+    return !that.isDisabled();
+  });
+},
 
-    checkDisabled: function () {
-      var that = this;
+tabIndex: function () {
+  if (this.$element.is('[tabindex]')) {
+    this.$element.data('tabindex', this.$element.attr('tabindex'));
+    this.$button.attr('tabindex', this.$element.data('tabindex'));
+  }
+},
 
-      if (this.isDisabled()) {
-        this.$button.addClass('disabled').attr('tabindex', -1);
-      } else {
-        if (this.$button.hasClass('disabled')) {
-          this.$button.removeClass('disabled');
-        }
+clickListener: function () {
+  var that = this;
 
-        if (this.$button.attr('tabindex') == -1) {
-          if (!this.$element.data('tabindex')) this.$button.removeAttr('tabindex');
-        }
-      }
+  this.$newElement.on('touchstart.dropdown', '.dropdown-menu', function (e) {
+    e.stopPropagation();
+  });
 
-      this.$button.click(function () {
-        return !that.isDisabled();
-      });
-    },
+  this.$newElement.on('click', function () {
+    that.setSize();
+    if (!that.options.liveSearch && !that.multiple) {
+      setTimeout(function () {
+        that.$menu.find('.selected a').focus();
+      }, 10);
+    }
+  });
 
-    tabIndex: function () {
-      if (this.$element.is('[tabindex]')) {
-        this.$element.data('tabindex', this.$element.attr('tabindex'));
-        this.$button.attr('tabindex', this.$element.data('tabindex'));
-      }
-    },
+  this.$menu.on('click', 'li a', function (e) {
+    var $this = $(this),
+        clickedIndex = $this.parent().data('originalIndex'),
+        prevValue = that.$element.val(),
+        prevIndex = that.$element.prop('selectedIndex');
 
-    clickListener: function () {
-      var that = this;
+    // Don't close on multi choice menu
+    if (that.multiple) {
+      e.stopPropagation();
+    }
 
-      this.$newElement.on('touchstart.dropdown', '.dropdown-menu', function (e) {
-        e.stopPropagation();
-      });
+    e.preventDefault();
 
-      this.$newElement.on('click', function () {
-        that.setSize();
-        if (!that.options.liveSearch && !that.multiple) {
-          setTimeout(function () {
-            that.$menu.find('.selected a').focus();
-          }, 10);
-        }
-      });
+    //Don't run if we have been disabled
+    if (!that.isDisabled() && !$this.parent().hasClass('disabled')) {
+      var $options = that.$element.find('option'),
+          $option = $options.eq(clickedIndex),
+          state = $option.prop('selected'),
+          $optgroup = $option.parent('optgroup'),
+          maxOptions = that.options.maxOptions,
+          maxOptionsGrp = $optgroup.data('maxOptions') || false;
 
-      this.$menu.on('click', 'li a', function (e) {
-        var $this = $(this),
-            clickedIndex = $this.parent().data('originalIndex'),
-            prevValue = that.$element.val(),
-            prevIndex = that.$element.prop('selectedIndex');
+      if (!that.multiple) { // Deselect all others if not multi select box
+        $options.prop('selected', false);
+        $option.prop('selected', true);
+        that.$menu.find('.selected').removeClass('selected');
+        that.setSelected(clickedIndex, true);
+      } else { // Toggle the one we have chosen if we are multi select.
+        $option.prop('selected', !state);
+        that.setSelected(clickedIndex, !state);
+        $this.blur();
 
-        // Don't close on multi choice menu
-        if (that.multiple) {
-          e.stopPropagation();
-        }
+        if (maxOptions !== false || maxOptionsGrp !== false) {
+          var maxReached = maxOptions < $options.filter(':selected').length,
+              maxReachedGrp = maxOptionsGrp < $optgroup.find('option:selected').length;
 
-        e.preventDefault();
+          if ((maxOptions && maxReached) || (maxOptionsGrp && maxReachedGrp)) {
+            if (maxOptions && maxOptions == 1) {
+              $options.prop('selected', false);
+              $option.prop('selected', true);
+              that.$menu.find('.selected').removeClass('selected');
+              that.setSelected(clickedIndex, true);
+            } else if (maxOptionsGrp && maxOptionsGrp == 1) {
+              $optgroup.find('option:selected').prop('selected', false);
+              $option.prop('selected', true);
+              var optgroupID = $this.data('optgroup');
 
-        //Don't run if we have been disabled
-        if (!that.isDisabled() && !$this.parent().hasClass('disabled')) {
-          var $options = that.$element.find('option'),
-              $option = $options.eq(clickedIndex),
-              state = $option.prop('selected'),
-              $optgroup = $option.parent('optgroup'),
-              maxOptions = that.options.maxOptions,
-              maxOptionsGrp = $optgroup.data('maxOptions') || false;
+              that.$menu.find('.selected').has('a[data-optgroup="' + optgroupID + '"]').removeClass('selected');
 
-          if (!that.multiple) { // Deselect all others if not multi select box
-            $options.prop('selected', false);
-            $option.prop('selected', true);
-            that.$menu.find('.selected').removeClass('selected');
-            that.setSelected(clickedIndex, true);
-          } else { // Toggle the one we have chosen if we are multi select.
-            $option.prop('selected', !state);
-            that.setSelected(clickedIndex, !state);
-            $this.blur();
-
-            if (maxOptions !== false || maxOptionsGrp !== false) {
-              var maxReached = maxOptions < $options.filter(':selected').length,
-                  maxReachedGrp = maxOptionsGrp < $optgroup.find('option:selected').length;
-
-              if ((maxOptions && maxReached) || (maxOptionsGrp && maxReachedGrp)) {
-                if (maxOptions && maxOptions == 1) {
-                  $options.prop('selected', false);
-                  $option.prop('selected', true);
-                  that.$menu.find('.selected').removeClass('selected');
-                  that.setSelected(clickedIndex, true);
-                } else if (maxOptionsGrp && maxOptionsGrp == 1) {
-                  $optgroup.find('option:selected').prop('selected', false);
-                  $option.prop('selected', true);
-                  var optgroupID = $this.data('optgroup');
-
-                  that.$menu.find('.selected').has('a[data-optgroup="' + optgroupID + '"]').removeClass('selected');
-
-                  that.setSelected(clickedIndex, true);
-                } else {
-                  var maxOptionsArr = (typeof that.options.maxOptionsText === 'function') ?
-                          that.options.maxOptionsText(maxOptions, maxOptionsGrp) : that.options.maxOptionsText,
-                      maxTxt = maxOptionsArr[0].replace('{n}', maxOptions),
-                      maxTxtGrp = maxOptionsArr[1].replace('{n}', maxOptionsGrp),
-                      $notify = $('<div class="notify"></div>');
-                  // If {var} is set in array, replace it
-                  /** @deprecated */
-                  if (maxOptionsArr[2]) {
-                    maxTxt = maxTxt.replace('{var}', maxOptionsArr[2][maxOptions > 1 ? 0 : 1]);
-                    maxTxtGrp = maxTxtGrp.replace('{var}', maxOptionsArr[2][maxOptionsGrp > 1 ? 0 : 1]);
-                  }
-
-                  $option.prop('selected', false);
-
-                  that.$menu.append($notify);
-
-                  if (maxOptions && maxReached) {
-                    $notify.append($('<div>' + maxTxt + '</div>'));
-                    that.$element.trigger('maxReached.bs.select');
-                  }
-
-                  if (maxOptionsGrp && maxReachedGrp) {
-                    $notify.append($('<div>' + maxTxtGrp + '</div>'));
-                    that.$element.trigger('maxReachedGrp.bs.select');
-                  }
-
-                  setTimeout(function () {
-                    that.setSelected(clickedIndex, false);
-                  }, 10);
-
-                  $notify.delay(750).fadeOut(300, function () {
-                    $(this).remove();
-                  });
-                }
+              that.setSelected(clickedIndex, true);
+            } else {
+              var maxOptionsArr = (typeof that.options.maxOptionsText === 'function') ?
+                      that.options.maxOptionsText(maxOptions, maxOptionsGrp) : that.options.maxOptionsText,
+                  maxTxt = maxOptionsArr[0].replace('{n}', maxOptions),
+                  maxTxtGrp = maxOptionsArr[1].replace('{n}', maxOptionsGrp),
+                  $notify = $('<div class="notify"></div>');
+              // If {var} is set in array, replace it
+              /** @deprecated */
+              if (maxOptionsArr[2]) {
+                maxTxt = maxTxt.replace('{var}', maxOptionsArr[2][maxOptions > 1 ? 0 : 1]);
+                maxTxtGrp = maxTxtGrp.replace('{var}', maxOptionsArr[2][maxOptionsGrp > 1 ? 0 : 1]);
               }
+
+              $option.prop('selected', false);
+
+              that.$menu.append($notify);
+
+              if (maxOptions && maxReached) {
+                $notify.append($('<div>' + maxTxt + '</div>'));
+                that.$element.trigger('maxReached.bs.select');
+              }
+
+              if (maxOptionsGrp && maxReachedGrp) {
+                $notify.append($('<div>' + maxTxtGrp + '</div>'));
+                that.$element.trigger('maxReachedGrp.bs.select');
+              }
+
+              setTimeout(function () {
+                that.setSelected(clickedIndex, false);
+              }, 10);
+
+              $notify.delay(750).fadeOut(300, function () {
+                $(this).remove();
+              });
             }
           }
-
-          if (!that.multiple) {
-            that.$button.focus();
-          } else if (that.options.liveSearch) {
-            that.$searchbox.focus();
-          }
-
-          // Trigger select 'change'
-          if ((prevValue != that.$element.val() && that.multiple) || (prevIndex != that.$element.prop('selectedIndex') && !that.multiple)) {
-            that.$element.change();
-          }
         }
-      });
+      }
 
-      this.$menu.on('click', 'li.disabled a, .popover-title, .popover-title :not(.close)', function (e) {
-        if (e.currentTarget == this) {
-          e.preventDefault();
-          e.stopPropagation();
-          if (!that.options.liveSearch) {
-            that.$button.focus();
-          } else {
-            that.$searchbox.focus();
-          }
-        }
-      });
-
-      this.$menu.on('click', 'li.divider, li.dropdown-header', function (e) {
-        e.preventDefault();
-        e.stopPropagation();
-        if (!that.options.liveSearch) {
-          that.$button.focus();
-        } else {
-          that.$searchbox.focus();
-        }
-      });
-
-      this.$menu.on('click', '.popover-title .close', function () {
+      if (!that.multiple) {
         that.$button.focus();
-      });
-
-      this.$searchbox.on('click', function (e) {
-        e.stopPropagation();
-      });
-
-
-      this.$menu.on('click', '.actions-btn', function (e) {
-        if (that.options.liveSearch) {
-          that.$searchbox.focus();
-        } else {
-          that.$button.focus();
-        }
-
-        e.preventDefault();
-        e.stopPropagation();
-
-        if ($(this).is('.bs-select-all')) {
-          that.selectAll();
-        } else {
-          that.deselectAll();
-        }
-        that.$element.change();
-      });
-
-      this.$element.change(function () {
-        that.render(false);
-      });
-    },
-
-    liveSearchListener: function () {
-      var that = this,
-          no_results = $('<li class="no-results"></li>');
-
-      this.$newElement.on('click.dropdown.data-api touchstart.dropdown.data-api', function () {
-        that.$menu.find('.active').removeClass('active');
-        if (!!that.$searchbox.val()) {
-          that.$searchbox.val('');
-          that.$lis.not('.is-hidden').removeClass('hidden');
-          if (!!no_results.parent().length) no_results.remove();
-        }
-        if (!that.multiple) that.$menu.find('.selected').addClass('active');
-        setTimeout(function () {
-          that.$searchbox.focus();
-        }, 10);
-      });
-
-      this.$searchbox.on('click.dropdown.data-api focus.dropdown.data-api touchend.dropdown.data-api', function (e) {
-        e.stopPropagation();
-      });
-
-      this.$searchbox.on('input propertychange', function () {
-        if (that.$searchbox.val()) {
-          var $searchBase = that.$lis.not('.is-hidden').removeClass('hidden').find('a');
-          if (that.options.liveSearchNormalize) {
-            $searchBase = $searchBase.not(':a' + that._searchStyle() + '(' + normalizeToBase(that.$searchbox.val()) + ')');
-          } else {
-            $searchBase = $searchBase.not(':' + that._searchStyle() + '(' + that.$searchbox.val() + ')');
-          }
-          $searchBase.parent().addClass('hidden');
-
-          that.$lis.filter('.dropdown-header').each(function () {
-            var $this = $(this),
-                optgroup = $this.data('optgroup');
-
-            if (that.$lis.filter('[data-optgroup=' + optgroup + ']').not($this).filter(':visible').length === 0) {
-              $this.addClass('hidden');
-            }
-          });
-
-          if (!that.$menu.find('li').filter(':visible:not(.no-results)').length) {
-            if (!!no_results.parent().length) {
-              no_results.remove();
-            }
-            no_results.html(that.options.noneResultsText.replace('{0}', '"' + htmlEscape(that.$searchbox.val()) + '"')).show();
-            that.$menu.find('li').last().after(no_results);
-          } else if (!!no_results.parent().length) {
-            no_results.remove();
-          }
-
-        } else {
-          that.$lis.not('.is-hidden').removeClass('hidden');
-          if (!!no_results.parent().length) {
-            no_results.remove();
-          }
-        }
-
-        that.$menu.find('li.active').removeClass('active');
-        that.$menu.find('li').filter(':visible:not(.divider)').eq(0).addClass('active').find('a').focus();
-        $(this).focus();
-      });
-    },
-
-    _searchStyle: function () {
-      var style = 'icontains';
-      switch (this.options.liveSearchStyle) {
-        case 'begins':
-        case 'startsWith':
-          style = 'ibegins';
-          break;
-        case 'contains':
-        default:
-          break; //no need to change the default
-      }
-
-      return style;
-    },
-
-    val: function (value) {
-      if (typeof value !== 'undefined') {
-        this.$element.val(value);
-        this.render();
-
-        return this.$element;
-      } else {
-        return this.$element.val();
-      }
-    },
-
-    selectAll: function () {
-      this.findLis();
-      this.$lis.not('.divider').not('.disabled').not('.selected').filter(':visible').find('a').click();
-    },
-
-    deselectAll: function () {
-      this.findLis();
-      this.$lis.not('.divider').not('.disabled').filter('.selected').filter(':visible').find('a').click();
-    },
-
-    keydown: function (e) {
-      var $this = $(this),
-          $parent = ($this.is('input')) ? $this.parent().parent() : $this.parent(),
-          $items,
-          that = $parent.data('this'),
-          index,
-          next,
-          first,
-          last,
-          prev,
-          nextPrev,
-          prevIndex,
-          isActive,
-          keyCodeMap = {
-            32: ' ',
-            48: '0',
-            49: '1',
-            50: '2',
-            51: '3',
-            52: '4',
-            53: '5',
-            54: '6',
-            55: '7',
-            56: '8',
-            57: '9',
-            59: ';',
-            65: 'a',
-            66: 'b',
-            67: 'c',
-            68: 'd',
-            69: 'e',
-            70: 'f',
-            71: 'g',
-            72: 'h',
-            73: 'i',
-            74: 'j',
-            75: 'k',
-            76: 'l',
-            77: 'm',
-            78: 'n',
-            79: 'o',
-            80: 'p',
-            81: 'q',
-            82: 'r',
-            83: 's',
-            84: 't',
-            85: 'u',
-            86: 'v',
-            87: 'w',
-            88: 'x',
-            89: 'y',
-            90: 'z',
-            96: '0',
-            97: '1',
-            98: '2',
-            99: '3',
-            100: '4',
-            101: '5',
-            102: '6',
-            103: '7',
-            104: '8',
-            105: '9'
-          };
-
-      if (that.options.liveSearch) $parent = $this.parent().parent();
-
-      if (that.options.container) $parent = that.$menu;
-
-      $items = $('[role=menu] li a', $parent);
-
-      isActive = that.$menu.parent().hasClass('open');
-
-      if (!isActive && /([0-9]|[A-z])/.test(String.fromCharCode(e.keyCode))) {
-        if (!that.options.container) {
-          that.setSize();
-          that.$menu.parent().addClass('open');
-          isActive = true;
-        } else {
-          that.$newElement.trigger('click');
-        }
+      } else if (that.options.liveSearch) {
         that.$searchbox.focus();
       }
 
-      if (that.options.liveSearch) {
-        if (/(^9$|27)/.test(e.keyCode.toString(10)) && isActive && that.$menu.find('.active').length === 0) {
-          e.preventDefault();
-          that.$menu.parent().removeClass('open');
-          that.$button.focus();
-        }
-        $items = $('[role=menu] li:not(.divider):not(.dropdown-header):visible a', $parent);
-        if (!$this.val() && !/(38|40)/.test(e.keyCode.toString(10))) {
-          if ($items.filter('.active').length === 0) {
-            $items = that.$newElement.find('li a');
-            if (that.options.liveSearchNormalize) {
-              $items = $items.filter(':a' + that._searchStyle() + '(' + normalizeToBase(keyCodeMap[e.keyCode]) + ')');
-            } else {
-              $items = $items.filter(':' + that._searchStyle() + '(' + keyCodeMap[e.keyCode] + ')');
-            }
-          }
-        }
+      // Trigger select 'change'
+      if ((prevValue != that.$element.val() && that.multiple) || (prevIndex != that.$element.prop('selectedIndex') && !that.multiple)) {
+        that.$element.change();
       }
-
-      if (!$items.length) return;
-
-      if (/(38|40)/.test(e.keyCode.toString(10))) {
-        index = $items.index($items.filter(':focus'));
-        first = $items.parent(':not(.disabled):visible').first().index();
-        last = $items.parent(':not(.disabled):visible').last().index();
-        next = $items.eq(index).parent().nextAll(':not(.disabled):visible').eq(0).index();
-        prev = $items.eq(index).parent().prevAll(':not(.disabled):visible').eq(0).index();
-        nextPrev = $items.eq(next).parent().prevAll(':not(.disabled):visible').eq(0).index();
-
-        if (that.options.liveSearch) {
-          $items.each(function (i) {
-            if ($(this).is(':not(.disabled)')) {
-              $(this).data('index', i);
-            }
-          });
-          index = $items.index($items.filter('.active'));
-          first = $items.filter(':not(.disabled):visible').first().data('index');
-          last = $items.filter(':not(.disabled):visible').last().data('index');
-          next = $items.eq(index).nextAll(':not(.disabled):visible').eq(0).data('index');
-          prev = $items.eq(index).prevAll(':not(.disabled):visible').eq(0).data('index');
-          nextPrev = $items.eq(next).prevAll(':not(.disabled):visible').eq(0).data('index');
-        }
-
-        prevIndex = $this.data('prevIndex');
-
-        if (e.keyCode == 38) {
-          if (that.options.liveSearch) index -= 1;
-          if (index != nextPrev && index > prev) index = prev;
-          if (index < first) index = first;
-          if (index == prevIndex) index = last;
-        }
-
-        if (e.keyCode == 40) {
-          if (that.options.liveSearch) index += 1;
-          if (index == -1) index = 0;
-          if (index != nextPrev && index < next) index = next;
-          if (index > last) index = last;
-          if (index == prevIndex) index = first;
-        }
-
-        $this.data('prevIndex', index);
-
-        if (!that.options.liveSearch) {
-          $items.eq(index).focus();
-        } else {
-          e.preventDefault();
-          if (!$this.is('.dropdown-toggle')) {
-            $items.removeClass('active');
-            $items.eq(index).addClass('active').find('a').focus();
-            $this.focus();
-          }
-        }
-
-      } else if (!$this.is('input')) {
-        var keyIndex = [],
-            count,
-            prevKey;
-
-        $items.each(function () {
-          if ($(this).parent().is(':not(.disabled)')) {
-            if ($.trim($(this).text().toLowerCase()).substring(0, 1) == keyCodeMap[e.keyCode]) {
-              keyIndex.push($(this).parent().index());
-            }
-          }
-        });
-
-        count = $(document).data('keycount');
-        count++;
-        $(document).data('keycount', count);
-
-        prevKey = $.trim($(':focus').text().toLowerCase()).substring(0, 1);
-
-        if (prevKey != keyCodeMap[e.keyCode]) {
-          count = 1;
-          $(document).data('keycount', count);
-        } else if (count >= keyIndex.length) {
-          $(document).data('keycount', 0);
-          if (count > keyIndex.length) count = 1;
-        }
-
-        $items.eq(keyIndex[count - 1]).focus();
-      }
-
-      // Select focused option if "Enter", "Spacebar" or "Tab" (when selectOnTab is true) are pressed inside the menu.
-      if ((/(13|32)/.test(e.keyCode.toString(10)) || (/(^9$)/.test(e.keyCode.toString(10)) && that.options.selectOnTab)) && isActive) {
-        if (!/(32)/.test(e.keyCode.toString(10))) e.preventDefault();
-        if (!that.options.liveSearch) {
-          var elem = $(':focus');
-          elem.click();
-          // Bring back focus for multiselects
-          elem.focus();
-          // Prevent screen from scrolling if the user hit the spacebar
-          e.preventDefault();
-        } else if (!/(32)/.test(e.keyCode.toString(10))) {
-          that.$menu.find('.active a').click();
-          $this.focus();
-        }
-        $(document).data('keycount', 0);
-      }
-
-      if ((/(^9$|27)/.test(e.keyCode.toString(10)) && isActive && (that.multiple || that.options.liveSearch)) || (/(27)/.test(e.keyCode.toString(10)) && !isActive)) {
-        that.$menu.parent().removeClass('open');
-        that.$button.focus();
-      }
-    },
-
-    mobile: function () {
-      this.$element.addClass('mobile-device').appendTo(this.$newElement);
-      if (this.options.container) this.$menu.hide();
-    },
-
-    refresh: function () {
-      this.$lis = null;
-      this.reloadLi();
-      this.render();
-      this.setWidth();
-      this.setStyle();
-      this.checkDisabled();
-      this.liHeight();
-    },
-
-    hide: function () {
-      this.$newElement.hide();
-    },
-
-    show: function () {
-      this.$newElement.show();
-    },
-
-    remove: function () {
-      this.$newElement.remove();
-      this.$element.remove();
     }
-  };
+  });
 
-  // SELECTPICKER PLUGIN DEFINITION
-  // ==============================
-  function Plugin(option, event) {
-    // get the args of the outer function..
-    var args = arguments;
-    // The arguments of the function are explicitly re-defined from the argument list, because the shift causes them
-    // to get lost/corrupted in android 2.3 and IE9 #715 #775
-    var _option = option,
-        _event = event;
-    [].shift.apply(args);
+  this.$menu.on('click', 'li.disabled a, .popover-title, .popover-title :not(.close)', function (e) {
+    if (e.currentTarget == this) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (!that.options.liveSearch) {
+        that.$button.focus();
+      } else {
+        that.$searchbox.focus();
+      }
+    }
+  });
 
-    var value;
-    var chain = this.each(function () {
-      var $this = $(this);
-      if ($this.is('select')) {
-        var data = $this.data('selectpicker'),
-            options = typeof _option == 'object' && _option;
+  this.$menu.on('click', 'li.divider, li.dropdown-header', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!that.options.liveSearch) {
+      that.$button.focus();
+    } else {
+      that.$searchbox.focus();
+    }
+  });
 
-        if (!data) {
-          var config = $.extend({}, Selectpicker.DEFAULTS, $.fn.selectpicker.defaults || {}, $this.data(), options);
-          $this.data('selectpicker', (data = new Selectpicker(this, config, _event)));
-        } else if (options) {
-          for (var i in options) {
-            if (options.hasOwnProperty(i)) {
-              data.options[i] = options[i];
-            }
-          }
+  this.$menu.on('click', '.popover-title .close', function () {
+    that.$button.focus();
+  });
+
+  this.$searchbox.on('click', function (e) {
+    e.stopPropagation();
+  });
+
+
+  this.$menu.on('click', '.actions-btn', function (e) {
+    if (that.options.liveSearch) {
+      that.$searchbox.focus();
+    } else {
+      that.$button.focus();
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    if ($(this).is('.bs-select-all')) {
+      that.selectAll();
+    } else {
+      that.deselectAll();
+    }
+    that.$element.change();
+  });
+
+  this.$element.change(function () {
+    that.render(false);
+  });
+},
+
+liveSearchListener: function () {
+  var that = this,
+      no_results = $('<li class="no-results"></li>');
+
+  this.$newElement.on('click.dropdown.data-api touchstart.dropdown.data-api', function () {
+    that.$menu.find('.active').removeClass('active');
+    if (!!that.$searchbox.val()) {
+      that.$searchbox.val('');
+      that.$lis.not('.is-hidden').removeClass('hidden');
+      if (!!no_results.parent().length) no_results.remove();
+    }
+    if (!that.multiple) that.$menu.find('.selected').addClass('active');
+    setTimeout(function () {
+      that.$searchbox.focus();
+    }, 10);
+  });
+
+  this.$searchbox.on('click.dropdown.data-api focus.dropdown.data-api touchend.dropdown.data-api', function (e) {
+    e.stopPropagation();
+  });
+
+  this.$searchbox.on('input propertychange', function () {
+    if (that.$searchbox.val()) {
+      var $searchBase = that.$lis.not('.is-hidden').removeClass('hidden').find('a');
+      if (that.options.liveSearchNormalize) {
+        $searchBase = $searchBase.not(':a' + that._searchStyle() + '(' + normalizeToBase(that.$searchbox.val()) + ')');
+      } else {
+        $searchBase = $searchBase.not(':' + that._searchStyle() + '(' + that.$searchbox.val() + ')');
+      }
+      $searchBase.parent().addClass('hidden');
+
+      that.$lis.filter('.dropdown-header').each(function () {
+        var $this = $(this),
+            optgroup = $this.data('optgroup');
+
+        if (that.$lis.filter('[data-optgroup=' + optgroup + ']').not($this).filter(':visible').length === 0) {
+          $this.addClass('hidden');
         }
+      });
 
-        if (typeof _option == 'string') {
-          if (data[_option] instanceof Function) {
-            value = data[_option].apply(data, args);
-          } else {
-            value = data.options[_option];
-          }
+      if (!that.$menu.find('li').filter(':visible:not(.no-results)').length) {
+        if (!!no_results.parent().length) {
+          no_results.remove();
+        }
+        no_results.html(that.options.noneResultsText.replace('{0}', '"' + htmlEscape(that.$searchbox.val()) + '"')).show();
+        that.$menu.find('li').last().after(no_results);
+      } else if (!!no_results.parent().length) {
+        no_results.remove();
+      }
+
+    } else {
+      that.$lis.not('.is-hidden').removeClass('hidden');
+      if (!!no_results.parent().length) {
+        no_results.remove();
+      }
+    }
+
+    that.$menu.find('li.active').removeClass('active');
+    that.$menu.find('li').filter(':visible:not(.divider)').eq(0).addClass('active').find('a').focus();
+    $(this).focus();
+  });
+},
+
+_searchStyle: function () {
+  var style = 'icontains';
+  switch (this.options.liveSearchStyle) {
+    case 'begins':
+    case 'startsWith':
+      style = 'ibegins';
+      break;
+    case 'contains':
+    default:
+      break; //no need to change the default
+  }
+
+  return style;
+},
+
+val: function (value) {
+  if (typeof value !== 'undefined') {
+    this.$element.val(value);
+    this.render();
+
+    return this.$element;
+  } else {
+    return this.$element.val();
+  }
+},
+
+selectAll: function () {
+  this.findLis();
+  this.$lis.not('.divider').not('.disabled').not('.selected').filter(':visible').find('a').click();
+},
+
+deselectAll: function () {
+  this.findLis();
+  this.$lis.not('.divider').not('.disabled').filter('.selected').filter(':visible').find('a').click();
+},
+
+keydown: function (e) {
+  var $this = $(this),
+      $parent = ($this.is('input')) ? $this.parent().parent() : $this.parent(),
+      $items,
+      that = $parent.data('this'),
+      index,
+      next,
+      first,
+      last,
+      prev,
+      nextPrev,
+      prevIndex,
+      isActive,
+      keyCodeMap = {
+        32: ' ',
+        48: '0',
+        49: '1',
+        50: '2',
+        51: '3',
+        52: '4',
+        53: '5',
+        54: '6',
+        55: '7',
+        56: '8',
+        57: '9',
+        59: ';',
+        65: 'a',
+        66: 'b',
+        67: 'c',
+        68: 'd',
+        69: 'e',
+        70: 'f',
+        71: 'g',
+        72: 'h',
+        73: 'i',
+        74: 'j',
+        75: 'k',
+        76: 'l',
+        77: 'm',
+        78: 'n',
+        79: 'o',
+        80: 'p',
+        81: 'q',
+        82: 'r',
+        83: 's',
+        84: 't',
+        85: 'u',
+        86: 'v',
+        87: 'w',
+        88: 'x',
+        89: 'y',
+        90: 'z',
+        96: '0',
+        97: '1',
+        98: '2',
+        99: '3',
+        100: '4',
+        101: '5',
+        102: '6',
+        103: '7',
+        104: '8',
+        105: '9'
+      };
+
+  if (that.options.liveSearch) $parent = $this.parent().parent();
+
+  if (that.options.container) $parent = that.$menu;
+
+  $items = $('[role=menu] li a', $parent);
+
+  isActive = that.$menu.parent().hasClass('open');
+
+  if (!isActive && /([0-9]|[A-z])/.test(String.fromCharCode(e.keyCode))) {
+    if (!that.options.container) {
+      that.setSize();
+      that.$menu.parent().addClass('open');
+      isActive = true;
+    } else {
+      that.$newElement.trigger('click');
+    }
+    that.$searchbox.focus();
+  }
+
+  if (that.options.liveSearch) {
+    if (/(^9$|27)/.test(e.keyCode.toString(10)) && isActive && that.$menu.find('.active').length === 0) {
+      e.preventDefault();
+      that.$menu.parent().removeClass('open');
+      that.$button.focus();
+    }
+    $items = $('[role=menu] li:not(.divider):not(.dropdown-header):visible a', $parent);
+    if (!$this.val() && !/(38|40)/.test(e.keyCode.toString(10))) {
+      if ($items.filter('.active').length === 0) {
+        $items = that.$newElement.find('li a');
+        if (that.options.liveSearchNormalize) {
+          $items = $items.filter(':a' + that._searchStyle() + '(' + normalizeToBase(keyCodeMap[e.keyCode]) + ')');
+        } else {
+          $items = $items.filter(':' + that._searchStyle() + '(' + keyCodeMap[e.keyCode] + ')');
+        }
+      }
+    }
+  }
+
+  if (!$items.length) return;
+
+  if (/(38|40)/.test(e.keyCode.toString(10))) {
+    index = $items.index($items.filter(':focus'));
+    first = $items.parent(':not(.disabled):visible').first().index();
+    last = $items.parent(':not(.disabled):visible').last().index();
+    next = $items.eq(index).parent().nextAll(':not(.disabled):visible').eq(0).index();
+    prev = $items.eq(index).parent().prevAll(':not(.disabled):visible').eq(0).index();
+    nextPrev = $items.eq(next).parent().prevAll(':not(.disabled):visible').eq(0).index();
+
+    if (that.options.liveSearch) {
+      $items.each(function (i) {
+        if ($(this).is(':not(.disabled)')) {
+          $(this).data('index', i);
+        }
+      });
+      index = $items.index($items.filter('.active'));
+      first = $items.filter(':not(.disabled):visible').first().data('index');
+      last = $items.filter(':not(.disabled):visible').last().data('index');
+      next = $items.eq(index).nextAll(':not(.disabled):visible').eq(0).data('index');
+      prev = $items.eq(index).prevAll(':not(.disabled):visible').eq(0).data('index');
+      nextPrev = $items.eq(next).prevAll(':not(.disabled):visible').eq(0).data('index');
+    }
+
+    prevIndex = $this.data('prevIndex');
+
+    if (e.keyCode == 38) {
+      if (that.options.liveSearch) index -= 1;
+      if (index != nextPrev && index > prev) index = prev;
+      if (index < first) index = first;
+      if (index == prevIndex) index = last;
+    }
+
+    if (e.keyCode == 40) {
+      if (that.options.liveSearch) index += 1;
+      if (index == -1) index = 0;
+      if (index != nextPrev && index < next) index = next;
+      if (index > last) index = last;
+      if (index == prevIndex) index = first;
+    }
+
+    $this.data('prevIndex', index);
+
+    if (!that.options.liveSearch) {
+      $items.eq(index).focus();
+    } else {
+      e.preventDefault();
+      if (!$this.is('.dropdown-toggle')) {
+        $items.removeClass('active');
+        $items.eq(index).addClass('active').find('a').focus();
+        $this.focus();
+      }
+    }
+
+  } else if (!$this.is('input')) {
+    var keyIndex = [],
+        count,
+        prevKey;
+
+    $items.each(function () {
+      if ($(this).parent().is(':not(.disabled)')) {
+        if ($.trim($(this).text().toLowerCase()).substring(0, 1) == keyCodeMap[e.keyCode]) {
+          keyIndex.push($(this).parent().index());
         }
       }
     });
 
-    if (typeof value !== 'undefined') {
-      //noinspection JSUnusedAssignment
-      return value;
-    } else {
-      return chain;
+    count = $(document).data('keycount');
+    count++;
+    $(document).data('keycount', count);
+
+    prevKey = $.trim($(':focus').text().toLowerCase()).substring(0, 1);
+
+    if (prevKey != keyCodeMap[e.keyCode]) {
+      count = 1;
+      $(document).data('keycount', count);
+    } else if (count >= keyIndex.length) {
+      $(document).data('keycount', 0);
+      if (count > keyIndex.length) count = 1;
     }
+
+    $items.eq(keyIndex[count - 1]).focus();
   }
 
-  var old = $.fn.selectpicker;
-  $.fn.selectpicker = Plugin;
-  $.fn.selectpicker.Constructor = Selectpicker;
+  // Select focused option if "Enter", "Spacebar" or "Tab" (when selectOnTab is true) are pressed inside the menu.
+  if ((/(13|32)/.test(e.keyCode.toString(10)) || (/(^9$)/.test(e.keyCode.toString(10)) && that.options.selectOnTab)) && isActive) {
+    if (!/(32)/.test(e.keyCode.toString(10))) e.preventDefault();
+    if (!that.options.liveSearch) {
+      var elem = $(':focus');
+      elem.click();
+      // Bring back focus for multiselects
+      elem.focus();
+      // Prevent screen from scrolling if the user hit the spacebar
+      e.preventDefault();
+    } else if (!/(32)/.test(e.keyCode.toString(10))) {
+      that.$menu.find('.active a').click();
+      $this.focus();
+    }
+    $(document).data('keycount', 0);
+  }
 
-  // SELECTPICKER NO CONFLICT
-  // ========================
-  $.fn.selectpicker.noConflict = function () {
-    $.fn.selectpicker = old;
-    return this;
-  };
+  if ((/(^9$|27)/.test(e.keyCode.toString(10)) && isActive && (that.multiple || that.options.liveSearch)) || (/(27)/.test(e.keyCode.toString(10)) && !isActive)) {
+    that.$menu.parent().removeClass('open');
+    that.$button.focus();
+  }
+},
 
-  $(document)
-      .data('keycount', 0)
-      .on('keydown', '.bootstrap-select [data-toggle=dropdown], .bootstrap-select [role=menu], .bs-searchbox input', Selectpicker.prototype.keydown)
-      .on('focusin.modal', '.bootstrap-select [data-toggle=dropdown], .bootstrap-select [role=menu], .bs-searchbox input', function (e) {
-        e.stopPropagation();
-      });
+mobile: function () {
+  this.$element.addClass('mobile-device').appendTo(this.$newElement);
+  if (this.options.container) this.$menu.hide();
+},
 
-  // SELECTPICKER DATA-API
-  // =====================
-  $(window).on('load.bs.select.data-api', function () {
-    $('.selectpicker').each(function () {
-      var $selectpicker = $(this);
-      Plugin.call($selectpicker, $selectpicker.data());
-    })
+refresh: function () {
+  this.$lis = null;
+  this.reloadLi();
+  this.render();
+  this.setWidth();
+  this.setStyle();
+  this.checkDisabled();
+  this.liHeight();
+},
+
+hide: function () {
+  this.$newElement.hide();
+},
+
+show: function () {
+  this.$newElement.show();
+},
+
+remove: function () {
+  this.$newElement.remove();
+  this.$element.remove();
+}
+};
+
+// SELECTPICKER PLUGIN DEFINITION
+// ==============================
+function Plugin(option, event) {
+// get the args of the outer function..
+var args = arguments;
+// The arguments of the function are explicitly re-defined from the argument list, because the shift causes them
+// to get lost/corrupted in android 2.3 and IE9 #715 #775
+var _option = option,
+    _event = event;
+[].shift.apply(args);
+
+var value;
+var chain = this.each(function () {
+  var $this = $(this);
+  if ($this.is('select')) {
+    var data = $this.data('selectpicker'),
+        options = typeof _option == 'object' && _option;
+
+    if (!data) {
+      var config = $.extend({}, Selectpicker.DEFAULTS, $.fn.selectpicker.defaults || {}, $this.data(), options);
+      $this.data('selectpicker', (data = new Selectpicker(this, config, _event)));
+    } else if (options) {
+      for (var i in options) {
+        if (options.hasOwnProperty(i)) {
+          data.options[i] = options[i];
+        }
+      }
+    }
+
+    if (typeof _option == 'string') {
+      if (data[_option] instanceof Function) {
+        value = data[_option].apply(data, args);
+      } else {
+        value = data.options[_option];
+      }
+    }
+  }
+});
+
+if (typeof value !== 'undefined') {
+  //noinspection JSUnusedAssignment
+  return value;
+} else {
+  return chain;
+}
+}
+
+var old = $.fn.selectpicker;
+$.fn.selectpicker = Plugin;
+$.fn.selectpicker.Constructor = Selectpicker;
+
+// SELECTPICKER NO CONFLICT
+// ========================
+$.fn.selectpicker.noConflict = function () {
+$.fn.selectpicker = old;
+return this;
+};
+
+$(document)
+  .data('keycount', 0)
+  .on('keydown', '.bootstrap-select [data-toggle=dropdown], .bootstrap-select [role=menu], .bs-searchbox input', Selectpicker.prototype.keydown)
+  .on('focusin.modal', '.bootstrap-select [data-toggle=dropdown], .bootstrap-select [role=menu], .bs-searchbox input', function (e) {
+    e.stopPropagation();
   });
-})(jQuery);
+
+// SELECTPICKER DATA-API
+// =====================
+$(window).on('load.bs.select.data-api', function () {
+$('.selectpicker').each(function () {
+  var $selectpicker = $(this);
+  Plugin.call($selectpicker, $selectpicker.data());
+})
+});

--- a/jsx/Select.js
+++ b/jsx/Select.js
@@ -3,6 +3,11 @@
 
 require('../js/bootstrap-select');
 
+var React = require('react');
+React.Bootstrap = require('react-bootstrap');
+
+var $ = require('jQuery');
+
 var BootstrapSelect = React.createClass({displayName: 'BootstrapSelect',
   getInitialState: function () {
     return {

--- a/package.json
+++ b/package.json
@@ -56,11 +56,17 @@
     "browserify": "^8.1.3",
     "gulp": "^3.8.10",
     "gulp-uglify": "^1.1.0",
+    "jquery": "^2.1.3",
     "react": "^0.12.2",
     "react-bootstrap": "^0.15",
     "react-tools": "^0.12.2",
     "reactify": "^1.0.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.0.0"
+  },
+  "devDependencies": {
+    "babelify": "^5.0.3",
+    "gulp-less": "^3.0.0",
+    "merge-stream": "^0.1.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "babelify": "^5.0.3",
     "gulp-less": "^3.0.0",
     "merge-stream": "^0.1.7"
+  },
   "peerDependencies": {
     "react": "^0.12.2"
   }


### PR DESCRIPTION
If you don't want to accept this pull request its cool, not sure the direction you want to go with this component. I tried using it as is and was having some issues on my project with the component wanting bootstrap and jQuery as global since I'm packaging everything up with webpack. I basically just included jQuery and react-bootstrap so they don't have to be global.

I also created a gulp task, not sure if you already have one not committed I noticed you had the modules needed already included such as browserify, reactify, ect.

The gulp task generates the css from the less, and looks at the examples directory and creates the bundles for each example (there is only one currently).

The example uses react-bootstrap elements for the most part, and is a .jsx just illustrating how to include `react-bootstrap-select`

Regardless awesome work converting this, this is exactly what I needed for a project at work, really appreciate the effort.
